### PR TITLE
fix(#5): scope state replication roles and extend unit timeout

### DIFF
--- a/.github/workflows/pulumi-unit.yml
+++ b/.github/workflows/pulumi-unit.yml
@@ -21,7 +21,7 @@ jobs:
   unit:
     name: Unit
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       PULUMI_SKIP_UPDATE_CHECK: "true"
     steps:

--- a/pulumi/infra/pulumi_state.py
+++ b/pulumi/infra/pulumi_state.py
@@ -72,6 +72,14 @@ def _replication_role_name(role_suffix: str) -> str:
     return f"{_REPLICATION_ROLE_NAME_PREFIX}{_truncate_role_suffix(role_suffix)}"
 
 
+def _replication_role_suffix(repo_name: str, environment: str | None = None) -> str:
+    """Build an environment-scoped suffix for S3 replication IAM roles."""
+    env = sanitize_bucket_component(
+        environment or settings.environment, "environment"
+    ).replace(".", "-")
+    return f"{_resource_suffix(repo_name)}-{env}"
+
+
 def _bucket_policy(arn: str) -> str:
     """Return a bucket policy that enforces TLS for Pulumi state objects."""
     return f"""
@@ -276,6 +284,7 @@ class PulumiStateBuckets(pulumi.ComponentResource):
         """Create state bucket resources for one managed repository."""
         bucket_name = state_bucket_name_for_repo(repo.name)
         suffix = _resource_suffix(repo.name)
+        role_suffix = _replication_role_suffix(repo.name)
         bucket = self._create_bucket(
             f"{component_name}-{suffix}",
             bucket_name=bucket_name,
@@ -303,6 +312,7 @@ class PulumiStateBuckets(pulumi.ComponentResource):
             component_name,
             repo_name=repo.name,
             suffix=suffix,
+            role_suffix=role_suffix,
             bucket=bucket,
             replica_bucket=replica_bucket,
         )
@@ -406,13 +416,14 @@ class PulumiStateBuckets(pulumi.ComponentResource):
         *,
         repo_name: str,
         suffix: str,
+        role_suffix: str,
         bucket: aws.s3.Bucket,
         replica_bucket: aws.s3.Bucket,
     ) -> tuple[aws.iam.Role, aws.iam.RolePolicy]:
         """Create the replication IAM role and inline policy for one bucket pair."""
         replication_role = aws.iam.Role(
             f"{component_name}-replication-role-{suffix}",
-            name=_replication_role_name(suffix),
+            name=_replication_role_name(role_suffix),
             assume_role_policy=apply_output(
                 bucket.arn, _replication_assume_role_policy
             ),

--- a/tests/pulumi/test_delivery_contracts.py
+++ b/tests/pulumi/test_delivery_contracts.py
@@ -29,7 +29,7 @@ PULL_REQUEST_WORKFLOW_TIMEOUTS = {
         "iam_validation": 15,
     },
     "pulumi-structural.yml": {"structural": 15},
-    "pulumi-unit.yml": {"unit": 15},
+    "pulumi-unit.yml": {"unit": 30},
     "python-quality.yml": {
         "ruff": 15,
         "ty": 15,

--- a/tests/unit/test_pulumi_state_helpers.py
+++ b/tests/unit/test_pulumi_state_helpers.py
@@ -67,6 +67,12 @@ def test_replication_role_name_limits_length():
     assert len(role_name) <= pulumi_state._MAX_IAM_ROLE_NAME_LENGTH  # nosec B101
 
 
+def test_replication_role_suffix_includes_environment(monkeypatch):
+    monkeypatch.setattr(pulumi_state.settings, "environment", "smoke2")
+    role_suffix = pulumi_state._replication_role_suffix("bootstrap-infrastructure")
+    assert role_suffix == "bootstrap-infrastructure-smoke2"  # nosec B101
+
+
 def test_replica_bucket_name_length_guard(pulumi_mocks, monkeypatch):  # noqa: ARG001
     monkeypatch.setattr(
         pulumi_state, "state_bucket_name_for_repo", lambda _repo: "a" * 60


### PR DESCRIPTION
# Pull Request

## Description
This follow-up PR repairs two concrete post-merge defects discovered after PR #2 landed on `main`:
- scope Pulumi state replication IAM role names by environment so ephemeral validation stacks do not collide with shared roles
- raise the `Pulumi Unit Tests` workflow timeout from 15 to 30 minutes so GitHub stops cancelling the unit suite before completion

## Related Issue
- Closes #5

## Motivation and Context
PR #2 merged successfully, but a real AWS smoke deployment on `main` exposed an IAM role name collision for ephemeral stacks, and the `Pulumi Unit Tests` workflow on both PR #2 and merged `main` was being cancelled at the workflow timeout boundary.

## How Has This Been Tested?
- `docker compose --env-file .env.empty run --rm pulumi uv run ruff check pulumi/infra/pulumi_state.py tests/unit/test_pulumi_state_helpers.py tests/pulumi/test_delivery_contracts.py`
- `docker compose --env-file .env.empty run --rm pulumi uv run pytest -q tests/unit/test_pulumi_state_helpers.py tests/pulumi/test_delivery_contracts.py`
- metadata-only AWS checks confirming the current test-account collision on `PulumiStateRepl-bootstrap-infrastructure`

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased CI/CD unit test execution timeout from 15 to 30 minutes to support longer-running tests

* **Tests**
  * Updated workflow timeout contract expectations
  * Added test for environment-aware resource naming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->