### PR TITLE
fix(#7): extend unit workflow timeout to 45 minutes

### DIFF
--- a/.github/workflows/pulumi-unit.yml
+++ b/.github/workflows/pulumi-unit.yml
@@ -21,7 +21,7 @@ jobs:
   unit:
     name: Unit
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       PULUMI_SKIP_UPDATE_CHECK: "true"
     steps:

--- a/tests/pulumi/test_delivery_contracts.py
+++ b/tests/pulumi/test_delivery_contracts.py
@@ -29,7 +29,7 @@ PULL_REQUEST_WORKFLOW_TIMEOUTS = {
         "iam_validation": 15,
     },
     "pulumi-structural.yml": {"structural": 15},
-    "pulumi-unit.yml": {"unit": 30},
+    "pulumi-unit.yml": {"unit": 45},
     "python-quality.yml": {
         "ruff": 15,
         "ty": 15,


### PR DESCRIPTION
# Pull Request

## Description
This follow-up PR raises the `Pulumi Unit Tests` timeout from 30 to 45 minutes after merged `main` still cancelled the unit job at `30m19s`. It also updates the workflow delivery contract test to match.

## Related Issue
- Closes #7

## Motivation and Context
PR #6 fixed the infrastructure regression and improved the unit workflow timeout from 15 to 30 minutes, but merged `main` still hit the timeout boundary without surfacing a code failure. This PR adjusts only the remaining CI contract so the real unit runtime can complete.

## How Has This Been Tested?
- `docker compose --env-file .env.empty run --rm pulumi uv run ruff check tests/pulumi/test_delivery_contracts.py`
- `docker compose --env-file .env.empty run --rm pulumi uv run pytest -q tests/pulumi/test_delivery_contracts.py`
- verified `main` run `24289410947` cancelled at `30m19s` in `Run unit suite inside Docker`

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow timeout configuration to allow extended runtime for unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->