### PR TITLE
fix(#9): isolate Pulumi unit test mocks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,12 +115,17 @@ def any_thread_event_loop_policy():
     asyncio.set_event_loop_policy(previous_policy)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def pulumi_mocks() -> TestMocks:
-    """Expose Pulumi mocks for tests that validate generated resources."""
+    """Expose isolated Pulumi mocks for tests that validate generated resources."""
     mocks = TestMocks()
     pulumi.runtime.set_mocks(mocks, project="bootstrap", stack="test", preview=False)
-    return mocks
+    try:
+        yield mocks
+    finally:
+        # Reset the synthetic root stack between tests so later modules can
+        # install their own Pulumi mock runtime without inheriting leaked state.
+        pulumi.runtime.settings.reset_options(project=None, stack=None)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/unit/test_components.py
+++ b/tests/unit/test_components.py
@@ -81,7 +81,9 @@ def test_components_build(pulumi_mocks, monkeypatch):  # noqa: ARG001
     assert automation.repository.repository_url is not None  # nosec B101
 
 
-def test_state_buckets_reject_same_replication_region(monkeypatch):
+def test_state_buckets_reject_same_replication_region(  # noqa: ARG001
+    monkeypatch, pulumi_mocks
+):
     monkeypatch.setattr(config.settings, "replication_region", "us-east-1")
 
     repos = [config.ManagedRepository(name="repo", default_branch="main")]
@@ -90,7 +92,9 @@ def test_state_buckets_reject_same_replication_region(monkeypatch):
         PulumiStateBuckets("pulumi-state-invalid", repositories=repos)
 
 
-def test_github_oidc_roles_with_existing_provider(monkeypatch):
+def test_github_oidc_roles_with_existing_provider(  # noqa: ARG001
+    monkeypatch, pulumi_mocks
+):
     class FakeProvider:
         arn = pulumi.Output.from_input(
             "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
@@ -238,7 +242,9 @@ def test_github_automation_requires_provider(monkeypatch):
         GitHubAutomation("github-automation-missing-provider")
 
 
-def test_github_oidc_roles_require_matching_kms_key(monkeypatch):
+def test_github_oidc_roles_require_matching_kms_key(  # noqa: ARG001
+    monkeypatch, pulumi_mocks
+):
     class FakeProvider:
         arn = pulumi.Output.from_input(
             "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
@@ -357,5 +363,104 @@ def test_stack_main_executes(pulumi_mocks, monkeypatch):  # noqa: ARG001
         stack_path = Path(__file__).resolve().parents[2] / "pulumi" / "__main__.py"
         # Keep a fast stack smoke test alongside the integration suite.
         runpy.run_path(str(stack_path))
+    finally:
+        config.managed_repositories.cache_clear()
+
+
+def test_stack_main_executes_bootstrap_repo_mode(  # noqa: ARG001
+    pulumi_mocks, monkeypatch
+):
+    config.managed_repositories.cache_clear()
+    try:
+        monkeypatch.setattr(config.settings, "repo", "repo")
+        monkeypatch.setattr(config.settings, "org", "VilnaCRM-Org")
+        monkeypatch.setattr(config.settings, "environment", "test")
+        monkeypatch.setattr(config.settings, "replication_region", "us-west-2")
+        monkeypatch.setattr(config.settings, "managed_repo_overrides", None)
+        monkeypatch.setattr(
+            config.settings,
+            "github_oidc_provider_arn",
+            "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com",
+        )
+
+        class FakeConfig:
+            def get(self, key, default=None):
+                values = {
+                    "environment": "test",
+                    "serviceName": "bootstrap-infrastructure",
+                    "repoSlug": "repo",
+                    "githubOrg": "VilnaCRM-Org",
+                    "githubBranch": "main",
+                    "githubOidcProviderArn": (
+                        "arn:aws:iam::123456789012:oidc-provider/"
+                        "token.actions.githubusercontent.com"
+                    ),
+                }
+                return values.get(key, default)
+
+            def get_object(self, key, default=None):
+                return {"managedRepositories": None}.get(key, default)
+
+        monkeypatch.setattr(pulumi, "Config", lambda: FakeConfig())
+        stack_path = Path(__file__).resolve().parents[2] / "pulumi" / "__main__.py"
+
+        module_globals = runpy.run_path(str(stack_path))
+
+        assert module_globals["state"].backend_urls  # nosec B101
+        assert module_globals["secrets"].provider_urls  # nosec B101
+        assert module_globals["oidc"].deploy_role_arns  # nosec B101
+        assert module_globals["automation"].repository.repository_url is not None  # nosec B101
+    finally:
+        config.managed_repositories.cache_clear()
+
+
+def test_stack_main_executes_managed_repository_mode_without_automation(  # noqa: ARG001
+    pulumi_mocks, monkeypatch
+):
+    config.managed_repositories.cache_clear()
+    try:
+        repo = config.ManagedRepository(name="repo-managed", default_branch="main")
+        monkeypatch.setattr(config.settings, "repo", None)
+        monkeypatch.setattr(config.settings, "org", "VilnaCRM-Org")
+        monkeypatch.setattr(config.settings, "environment", "test")
+        monkeypatch.setattr(config.settings, "replication_region", "us-west-2")
+        monkeypatch.setattr(config.settings, "managed_repo_overrides", [repo])
+        monkeypatch.setattr(
+            config.settings,
+            "github_oidc_provider_arn",
+            "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com",
+        )
+
+        class FakeConfig:
+            def get(self, key, default=None):
+                values = {
+                    "environment": "test",
+                    "serviceName": "bootstrap-infrastructure",
+                    "githubOrg": "VilnaCRM-Org",
+                    "githubBranch": "main",
+                    "githubOidcProviderArn": (
+                        "arn:aws:iam::123456789012:oidc-provider/"
+                        "token.actions.githubusercontent.com"
+                    ),
+                }
+                return values.get(key, default)
+
+            def get_object(self, key, default=None):
+                values = {
+                    "managedRepositories": [
+                        {"name": "repo-managed", "defaultBranch": "main"}
+                    ]
+                }
+                return values.get(key, default)
+
+        monkeypatch.setattr(pulumi, "Config", lambda: FakeConfig())
+        stack_path = Path(__file__).resolve().parents[2] / "pulumi" / "__main__.py"
+
+        module_globals = runpy.run_path(str(stack_path))
+
+        assert module_globals["state"].backend_urls  # nosec B101
+        assert module_globals["secrets"].provider_urls  # nosec B101
+        assert module_globals["oidc"].deploy_role_arns  # nosec B101
+        assert "automation" not in module_globals  # nosec B101
     finally:
         config.managed_repositories.cache_clear()

--- a/tests/unit/test_pulumi_state_helpers.py
+++ b/tests/unit/test_pulumi_state_helpers.py
@@ -73,6 +73,34 @@ def test_replication_role_suffix_includes_environment(monkeypatch):
     assert role_suffix == "bootstrap-infrastructure-smoke2"  # nosec B101
 
 
+def test_resource_options_include_import_id(monkeypatch):
+    captured = {}
+
+    def fake_resource_options(**kwargs):
+        captured.update(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(pulumi_state.pulumi, "ResourceOptions", fake_resource_options)
+
+    options = pulumi_state._resource_options(object(), import_id="bucket-id")
+
+    assert options["import_"] == "bucket-id"  # nosec B101
+    assert captured["import_"] == "bucket-id"  # nosec B101
+
+
+def test_replica_import_id_returns_existing_bucket(monkeypatch):
+    monkeypatch.setattr(
+        pulumi_state, "_bucket_exists", lambda _name, provider=None: True
+    )
+
+    component = object.__new__(pulumi_state.PulumiStateBuckets)
+
+    assert (
+        component._replica_import_id("repo-state", replica_provider=object())
+        == "repo-state-replication"
+    )  # nosec B101
+
+
 def test_replica_bucket_name_length_guard(pulumi_mocks, monkeypatch):  # noqa: ARG001
     monkeypatch.setattr(
         pulumi_state, "state_bucket_name_for_repo", lambda _repo: "a" * 60


### PR DESCRIPTION
## Summary
- isolate the shared `pulumi_mocks` fixture per test and reset Pulumi runtime state after each use
- make component tests that instantiate Pulumi resources request the mock fixture explicitly
- add focused unit coverage for the bootstrap path in `pulumi/__main__.py` and the remaining `pulumi_state` helper branches

## Validation
- `docker compose --env-file .env.empty run --rm pulumi uv run ruff check tests/conftest.py tests/unit/test_components.py tests/unit/test_pulumi_state_helpers.py`
- `docker compose --env-file .env.empty run --rm pulumi uv run pytest -q tests/unit`
- `docker compose --env-file .env.empty run --rm -e COVERAGE_FILE=/workspace/.coverage.unit -e COVERAGE_RCFILE=/workspace/.coveragerc -e PYTEST_ADDOPTS='--cov=./pulumi --cov-report=term-missing --cov=./scripts' pulumi bash -lc 'uv run pytest -q tests/unit && uv run coverage report --show-missing --include="pulumi/*,scripts/*" --fail-under=100'`

Closes #9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Enhanced test isolation by ensuring mock and runtime state is properly reset between test executions
* Added smoke tests for stack entrypoint execution in bootstrap repository mode and managed repository mode scenarios, validating proper configuration propagation
* Expanded test coverage for import ID functionality in state management operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->