### PR TITLE
fix(ci): allow main guardrails to use backend fallback

### DIFF
--- a/.github/workflows/pulumi-pr-guardrails.yml
+++ b/.github/workflows/pulumi-pr-guardrails.yml
@@ -57,9 +57,9 @@ jobs:
       AWS_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
       AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
       AWS_PREVIEW_ROLE_ARN: ${{ vars.AWS_PREVIEW_ROLE_ARN }}
-      PULUMI_BACKEND_URL: ${{ github.event_name == 'pull_request' && vars.PULUMI_PR_BACKEND_URL || vars.PULUMI_BACKEND_URL }}
+      PULUMI_BACKEND_URL: ${{ github.event_name == 'pull_request' && vars.PULUMI_PR_BACKEND_URL || vars.PULUMI_BACKEND_URL || vars.PULUMI_PR_BACKEND_URL }}
       PULUMI_SECRETS_PROVIDER: ${{ vars.PULUMI_SECRETS_PROVIDER }}
-      PULUMI_PREVIEW_STACKS: ${{ github.event_name == 'pull_request' && vars.PULUMI_PR_PREVIEW_STACKS || vars.PULUMI_PREVIEW_STACKS }}
+      PULUMI_PREVIEW_STACKS: ${{ github.event_name == 'pull_request' && vars.PULUMI_PR_PREVIEW_STACKS || vars.PULUMI_PREVIEW_STACKS || vars.PULUMI_PR_PREVIEW_STACKS }}
       PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/tests/pulumi/test_ci_guardrails.py
+++ b/tests/pulumi/test_ci_guardrails.py
@@ -143,11 +143,13 @@ def test_preview_guardrail_workflow_requires_preview_diff_and_iam_jobs() -> None
     destructive_diff_job_if = " ".join(jobs["destructive_diff"]["if"].split())
     pr_backend_expression = (
         "${{ github.event_name == 'pull_request' && "
-        + "vars.PULUMI_PR_BACKEND_URL || vars.PULUMI_BACKEND_URL }}"
+        + "vars.PULUMI_PR_BACKEND_URL || vars.PULUMI_BACKEND_URL || "
+        + "vars.PULUMI_PR_BACKEND_URL }}"
     )
     pr_stack_expression = (
         "${{ github.event_name == 'pull_request' && "
-        + "vars.PULUMI_PR_PREVIEW_STACKS || vars.PULUMI_PREVIEW_STACKS }}"
+        + "vars.PULUMI_PR_PREVIEW_STACKS || vars.PULUMI_PREVIEW_STACKS || "
+        + "vars.PULUMI_PR_PREVIEW_STACKS }}"
     )
 
     assert workflow["concurrency"]["cancel-in-progress"] is True


### PR DESCRIPTION
## Summary

- Fixes the main-branch Pulumi PR Guardrails failure after PR #22 landed.
- Lets the preview job use the existing PR backend/stack fallback variables when shared main variables are absent, matching the test deploy workflow fallback contract.
- Updates the structural workflow test for the expression.

## Testing

- `uv run pytest -q tests/pulumi/test_ci_guardrails.py::test_preview_guardrail_workflow_requires_preview_diff_and_iam_jobs`
- `uv run pytest -q tests/pulumi/test_ci_guardrails.py`

## Context

The PR #22 merge successfully completed `Pulumi Test Deploy`, including test preview, destructive diff, IAM validation, real test apply, and post-apply drift. The only failed merge workflow was `Pulumi PR Guardrails`, which failed before preview because `PULUMI_BACKEND_URL` and `PULUMI_PREVIEW_STACKS` were empty on the `push` event while the test environment still has the fallback `PULUMI_PR_*` variables.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Pulumi PR Guardrails workflow on `main` so previews run even when shared `main` variables are empty by falling back to PR backend and stack vars. Aligns the `main` workflow with the test deploy fallback behavior.

- **Bug Fixes**
  - In `.github/workflows/pulumi-pr-guardrails.yml`, updated `PULUMI_BACKEND_URL` and `PULUMI_PREVIEW_STACKS` to also fall back to `vars.PULUMI_PR_BACKEND_URL` and `vars.PULUMI_PR_PREVIEW_STACKS`.
  - Updated `tests/pulumi/test_ci_guardrails.py` to assert the new fallback expressions.

<sup>Written for commit 03a97f0fd153f83c768c82e74fc21d9b1bd15cab. Summary will update on new commits. <a href="https://cubic.dev/pr/VilnaCRM-Org/bootstrap-infrastructure/pull/32?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pulumi preview workflow now supports PR-specific environment variable fallbacks for backend URL and preview stacks.
  * Updated corresponding test expectations to validate the new configuration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VilnaCRM-Org/bootstrap-infrastructure/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->