### PR TITLE
[codex] Handle branch Well-Architected evidence context

### DIFF
--- a/scripts/_well_architected_scoring.py
+++ b/scripts/_well_architected_scoring.py
@@ -51,12 +51,17 @@ def pillar_scores(checks: Sequence[dict[str, object]]) -> dict[str, float]:
     by_name = {str(check["name"]): check for check in checks}
     scores: dict[str, float] = {}
     for pillar, check_names in PILLAR_CHECKS.items():
+        applicable = [
+            check_name
+            for check_name in check_names
+            if by_name.get(check_name, {}).get("status") != "not_applicable"
+        ]
         passed = sum(
             1
-            for check_name in check_names
+            for check_name in applicable
             if by_name.get(check_name, {}).get("status") == "passed"
         )
-        scores[pillar] = round(5 * passed / len(check_names), 2)
+        scores[pillar] = round(5 * passed / len(applicable), 2) if applicable else 5.0
     return scores
 
 

--- a/scripts/collect_well_architected_evidence.py
+++ b/scripts/collect_well_architected_evidence.py
@@ -472,9 +472,7 @@ def collect_evidence(
 ) -> dict[str, Any]:
     """Collect metadata-only Well-Architected evidence."""
     checks = [
-        github_pr_checks(args.repo, args.pr, runner=runner),
-        github_pr_local_state(args.repo, args.pr, args.root_dir, runner=runner),
-        github_review_threads(args.repo, args.pr, runner=runner),
+        *github_pr_context_evidence(args, runner=runner),
         github_branch_protection(
             args.repo,
             args.branch,
@@ -533,6 +531,49 @@ def collect_evidence(
         "scoreBlockers": score_blockers(checks),
         "blockers": [*_all_blockers(checks), *score_blockers(checks)],
     }
+
+
+def github_pr_context_evidence(
+    args: argparse.Namespace, *, runner: Runner = run
+) -> list[dict[str, object]]:
+    """Return PR evidence when available, or mark PR-only gates not applicable."""
+    if args.pr is not None:
+        return [
+            github_pr_checks(args.repo, args.pr, runner=runner),
+            github_pr_local_state(args.repo, args.pr, args.root_dir, runner=runner),
+            github_review_threads(args.repo, args.pr, runner=runner),
+        ]
+
+    return [
+        _not_applicable_pr_check(
+            "github_pr_checks",
+            args.branch,
+            "No pull request number is available in this branch evidence context.",
+        ),
+        _not_applicable_pr_check(
+            "github_pr_local_state",
+            args.branch,
+            "Local PR head comparison only applies to pull request evidence.",
+        ),
+        _not_applicable_pr_check(
+            "github_review_threads",
+            args.branch,
+            "Review-thread evidence only applies to pull request evidence.",
+        ),
+    ]
+
+
+def _not_applicable_pr_check(name: str, branch: str, reason: str) -> dict[str, object]:
+    """Return a normalized branch-context result for PR-only evidence checks."""
+    return _check(
+        name,
+        status="not_applicable",
+        evidence={
+            "branch": branch,
+            "reason": reason,
+            "scope": "branch",
+        },
+    )
 
 
 def render_markdown_report(report: dict[str, Any]) -> str:

--- a/scripts/render_well_architected_closeout.py
+++ b/scripts/render_well_architected_closeout.py
@@ -18,6 +18,7 @@ OPTIONAL_EVIDENCE_PLACEHOLDER = "<path-if-needed>"
 REVIEWER_LOGIN_PLACEHOLDER = "<reviewer-login>"
 APPROVAL_DECISION_PLACEHOLDER = "<approved|approved_exception|accepted_risk>"
 DATE_PLACEHOLDER = "<YYYY-MM-DD>"
+NON_BLOCKING_CHECK_STATUSES = frozenset({"passed", "not_applicable"})
 
 
 def _load_json_object(path: Path) -> dict[str, Any]:
@@ -229,6 +230,35 @@ def _prompt_checklist_lines(
         _string_entries(pr_checks.get("changedFileTopLevelPaths"))
     )
     score_scale = _score_scale_summary(question_matrix.get("scoreScale"))
+    if _branch_context(pr_checks):
+        branch = evidence_report.get("branch", "")
+        pr_artifact_evidence = (
+            f"Branch `{branch}` evidence context; PR-specific checks are marked "
+            "`not_applicable`"
+        )
+        pr_coverage = (
+            "PR gates remain enforced for pull_request evidence; branch evidence "
+            "relies on branch protection plus current branch workflow status."
+        )
+        pr_result = "not applicable for branch evidence"
+    else:
+        pr_artifact_evidence = (
+            f"PR head `{pr_head}`; hosted checks {pr_checks.get('checkCount', '')}; "
+            "non-passing hosted checks "
+            f"{pr_checks.get('nonPassingCheckCount', '')}; "
+            f"local dirty files {local_state.get('dirtyFileCount', '')}; "
+            f"changed files {pr_checks.get('changedFileCount', '')}; "
+            f"changed top-level paths {changed_top_level}"
+        )
+        pr_coverage = (
+            "Hosted PR gates, changed-file metadata, and local evidence state cover "
+            "the reviewed branch; repository-owned tests still need to stay green "
+            "after every new push"
+        )
+        pr_result = (
+            f"merge state {pr_checks.get('mergeStateStatus', '')}; review decision "
+            f"{pr_checks.get('reviewDecision', '') or 'empty'}"
+        )
     return [
         "## Prompt-To-Artifact Checklist",
         "",
@@ -246,17 +276,7 @@ def _prompt_checklist_lines(
         ),
         (
             "| Check PR code and whole project code | "
-            f"PR head `{pr_head}`; hosted checks "
-            f"{pr_checks.get('checkCount', '')}; non-passing hosted checks "
-            f"{pr_checks.get('nonPassingCheckCount', '')}; local dirty files "
-            f"{local_state.get('dirtyFileCount', '')}; changed files "
-            f"{pr_checks.get('changedFileCount', '')}; changed top-level paths "
-            f"{changed_top_level} | "
-            "Hosted PR gates, changed-file metadata, and local evidence state cover "
-            "the reviewed branch; repository-owned tests still need to stay green "
-            "after every new push | "
-            f"merge state {pr_checks.get('mergeStateStatus', '')}; review decision "
-            f"{pr_checks.get('reviewDecision', '') or 'empty'} |"
+            f"{pr_artifact_evidence} | {pr_coverage} | {pr_result} |"
         ),
         (
             "| Put scores from 1 to 5 | "
@@ -280,6 +300,82 @@ def _prompt_checklist_lines(
     ]
 
 
+def _branch_context(pr_checks: dict[str, Any]) -> bool:
+    return pr_checks.get("scope") == "branch"
+
+
+def _pull_request_state_lines(
+    pr_checks: dict[str, Any],
+    local_state: dict[str, Any],
+    review_threads: dict[str, Any],
+) -> list[str]:
+    if _branch_context(pr_checks):
+        return [
+            "## Pull Request State",
+            "",
+            "Not applicable in this branch evidence context; no pull request "
+            "number was supplied.",
+            "",
+        ]
+
+    return [
+        "## Pull Request State",
+        "",
+        _table(
+            [
+                ("PR head SHA", pr_checks.get("headRefOid", "")),
+                ("Local head SHA", local_state.get("localHead", "")),
+                ("Dirty file count", local_state.get("dirtyFileCount", "")),
+                ("Hosted check count", pr_checks.get("checkCount", "")),
+                (
+                    "Non-passing hosted checks",
+                    pr_checks.get("nonPassingCheckCount", ""),
+                ),
+                ("Changed file count", pr_checks.get("changedFileCount", "")),
+                (
+                    "Changed top-level paths",
+                    _comma_list(
+                        _string_entries(pr_checks.get("changedFileTopLevelPaths"))
+                    ),
+                ),
+                ("Review decision", pr_checks.get("reviewDecision", "")),
+                ("Merge state", pr_checks.get("mergeStateStatus", "")),
+                ("Mergeable", pr_checks.get("mergeable", "")),
+                ("Review thread count", review_threads.get("threadCount", "")),
+                (
+                    "Unresolved review threads",
+                    review_threads.get("unresolvedThreadCount", ""),
+                ),
+                (
+                    "Advisory unresolved review threads",
+                    review_threads.get("advisoryUnresolvedThreadCount", ""),
+                ),
+                (
+                    "Blocking review threads",
+                    review_threads.get("blockingThreadCount", ""),
+                ),
+                (
+                    "Outdated unresolved review threads",
+                    review_threads.get("outdatedUnresolvedThreadCount", ""),
+                ),
+            ]
+        ),
+        "",
+    ]
+
+
+def _reviewer_action_lines(pr_head: object) -> list[str]:
+    return [
+        "### Reviewer",
+        "",
+        "- Review and approve the latest PR head SHA after checking the current "
+        f"diff and hosted checks: `{pr_head}`.",
+        "- Do not rely on approvals from earlier commits when GitHub reports an "
+        "empty review decision.",
+        "",
+    ]
+
+
 def render_closeout_bundle(
     evidence_report: dict[str, Any], question_verification: dict[str, Any]
 ) -> str:
@@ -294,7 +390,11 @@ def render_closeout_bundle(
     question_matrix = _check_evidence(checks_by_name, "question_matrix_evidence")
     external_controls = _check_evidence(checks_by_name, "external_control_evidence")
 
-    failed_checks = [check for check in checks if check.get("status") != "passed"]
+    failed_checks = [
+        check
+        for check in checks
+        if check.get("status") not in NON_BLOCKING_CHECK_STATUSES
+    ]
     failed_check_rows = _failed_check_rows(failed_checks)
     unresolved_questions = _string_entries(
         question_verification.get("evidenceUnresolvedQuestionIds")
@@ -307,6 +407,9 @@ def render_closeout_bundle(
     )
     repo = str(evidence_report.get("repo", ""))
     pr_head = pr_checks.get("headRefOid", "")
+    reviewer_lines = (
+        _reviewer_action_lines(pr_head) if evidence_report.get("pr") else []
+    )
     final_collector_command = _collector_command(
         evidence_report.get("pr", ""),
         alert_route.get("topicArn", ""),
@@ -350,48 +453,7 @@ def render_closeout_bundle(
             goal_status,
             evidence_report,
         ),
-        "## Pull Request State",
-        "",
-        _table(
-            [
-                ("PR head SHA", pr_head),
-                ("Local head SHA", local_state.get("localHead", "")),
-                ("Dirty file count", local_state.get("dirtyFileCount", "")),
-                ("Hosted check count", pr_checks.get("checkCount", "")),
-                (
-                    "Non-passing hosted checks",
-                    pr_checks.get("nonPassingCheckCount", ""),
-                ),
-                ("Changed file count", pr_checks.get("changedFileCount", "")),
-                (
-                    "Changed top-level paths",
-                    _comma_list(
-                        _string_entries(pr_checks.get("changedFileTopLevelPaths"))
-                    ),
-                ),
-                ("Review decision", pr_checks.get("reviewDecision", "")),
-                ("Merge state", pr_checks.get("mergeStateStatus", "")),
-                ("Mergeable", pr_checks.get("mergeable", "")),
-                ("Review thread count", review_threads.get("threadCount", "")),
-                (
-                    "Unresolved review threads",
-                    review_threads.get("unresolvedThreadCount", ""),
-                ),
-                (
-                    "Advisory unresolved review threads",
-                    review_threads.get("advisoryUnresolvedThreadCount", ""),
-                ),
-                (
-                    "Blocking review threads",
-                    review_threads.get("blockingThreadCount", ""),
-                ),
-                (
-                    "Outdated unresolved review threads",
-                    review_threads.get("outdatedUnresolvedThreadCount", ""),
-                ),
-            ]
-        ),
-        "",
+        *_pull_request_state_lines(pr_checks, local_state, review_threads),
         "## Remaining Collector Gates",
         "",
         "| Check | Status | Blockers |",
@@ -453,13 +515,7 @@ def render_closeout_bundle(
             "",
             "## Required Owner Actions",
             "",
-            "### Reviewer",
-            "",
-            "- Review and approve the latest PR head SHA after checking the current "
-            f"diff and hosted checks: `{pr_head}`.",
-            "- Do not rely on approvals from earlier commits when GitHub reports an "
-            "empty review decision.",
-            "",
+            *reviewer_lines,
             "### Repository Admin",
             "",
             "- Apply and verify repository controls with "

--- a/tests/unit/test_script_entrypoints.py
+++ b/tests/unit/test_script_entrypoints.py
@@ -2788,11 +2788,32 @@ def test_render_well_architected_closeout_handles_clean_and_invalid_inputs(
             "evidenceUnresolvedQuestionIds": "not a list",
         },
     )
+    branch_text = module.render_closeout_bundle(
+        {
+            "generatedAt": "2026-05-11T00:00:00Z",
+            "branch": "main",
+            "checks": [
+                {
+                    "name": "github_pr_checks",
+                    "status": "not_applicable",
+                    "evidence": {"branch": "main", "scope": "branch"},
+                    "blockers": [],
+                }
+            ],
+        },
+        {"checkedAt": "2026-05-11T00:01:00Z"},
+    )
     invalid = tmp_path / "invalid.json"
     output = tmp_path / "bundle.md"
     invalid.write_text("[]", encoding="utf-8")
 
     assert "| None | passed | None |" in text  # nosec B101
+    assert "| None | passed | None |" in branch_text  # nosec B101
+    assert "github_pr_checks | not_applicable" not in branch_text  # nosec B101
+    assert "Branch `main` evidence context" in branch_text  # nosec B101
+    assert "Not applicable in this branch evidence context" in branch_text  # nosec B101
+    assert "| PR head SHA |" not in branch_text  # nosec B101
+    assert "### Reviewer" not in branch_text  # nosec B101
     assert "| Current final scores | None |" in text  # nosec B101
     assert "| Unresolved question IDs | None |" in text  # nosec B101
     assert "| Unresolved control IDs | None |" in text  # nosec B101
@@ -5321,6 +5342,49 @@ def test_score_blockers_distinguish_failed_and_missing_gates(
             "can be treated as final Well-Architected scores."
         ),
     ]
+
+
+def test_branch_evidence_marks_pr_gates_not_applicable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Branch evidence should not fail PR-only checks when no PR exists."""
+    module = load_script_module(monkeypatch, "collect_well_architected_evidence")
+    args = module.build_parser().parse_args(
+        ["--repo", "org/repo", "--branch", "main", "--root-dir", str(tmp_path)]
+    )
+
+    checks = module.github_pr_context_evidence(args)
+
+    assert [check["name"] for check in checks] == [  # nosec B101
+        "github_pr_checks",
+        "github_pr_local_state",
+        "github_review_threads",
+    ]
+    assert {check["status"] for check in checks} == {  # nosec B101
+        "not_applicable"
+    }
+    assert all(not check["blockers"] for check in checks)  # nosec B101
+    assert all(check["evidence"]["branch"] == "main" for check in checks)  # nosec B101
+
+
+def test_pillar_scores_ignore_not_applicable_pr_gates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-PR branch evidence should not depress pillar scores for PR-only gates."""
+    module = load_script_module(monkeypatch, "collect_well_architected_evidence")
+    checks = [
+        {"name": "github_pr_checks", "status": "not_applicable"},
+        {"name": "github_pr_local_state", "status": "not_applicable"},
+        {"name": "github_review_threads", "status": "not_applicable"},
+        {"name": "github_branch_protection", "status": "passed"},
+        {"name": "github_production_environment", "status": "passed"},
+        {"name": "aws_sns_alert_route", "status": "passed"},
+        {"name": "aws_cloudtrail_management_events", "status": "passed"},
+    ]
+
+    scores = module.pillar_scores(checks)
+
+    assert scores["Operational Excellence"] == pytest.approx(5.0)  # nosec B101
 
 
 def test_collect_well_architected_evidence_unknown_and_missing_paths(


### PR DESCRIPTION
## Summary

- Mark PR-only Well-Architected evidence gates as `not_applicable` when the collector runs without a pull request number, such as `push`/`main` branch evidence.
- Keep pull request evidence behavior unchanged when `--pr`/`PR_NUMBER` is supplied.
- Exclude `not_applicable` checks from closeout failures and pillar score denominators so branch closeout reports only real owner/admin blockers.

## Root Cause

The hosted Well-Architected workflow runs on both PR and branch contexts, but `PR_NUMBER` is empty on `push`/`main`. The collector treated that as failed PR evidence, so default-branch owner closeout bundles included stale PR-specific blockers even though no PR existed.

## Validation

- `uv run ruff check scripts/collect_well_architected_evidence.py scripts/_well_architected_scoring.py scripts/render_well_architected_closeout.py tests/unit/test_script_entrypoints.py`
- `uv run pytest -q tests/unit/test_script_entrypoints.py` (`139 passed`)
- `git diff --check`
- `make verify-well-architected-questions`
- `make report-well-architected-evidence` exits nonzero as expected for remaining owner/admin evidence gaps, but the PR-only gates are now `not_applicable` in branch context.
- `make report-well-architected-closeout`

## Remaining Manual Blockers

This does not close the final Well-Architected objective by itself. Remaining manual/admin work includes applying required status checks to the active `main` ruleset, creating/protecting the `prod` environment, security-owner IAM access attestation or remediation, and SRE/production-owner evidence for downstream alert consumption and DR readiness.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks PR-only Well‑Architected evidence checks as `not_applicable` when collecting on branches (no PR number), so branch closeout shows only real blockers and pillar scores stay accurate. PR behavior is unchanged when `--pr` is provided.

- **Bug Fixes**
  - Added `github_pr_context_evidence` to return PR evidence for `--pr`, or emit `not_applicable` for `github_pr_checks`, `github_pr_local_state`, and `github_review_threads` in branch context.
  - Updated pillar scoring to ignore `not_applicable` checks and default to 5.0 if none apply.
  - Treated `not_applicable` as non-blocking in closeout; show branch context in the checklist and Pull Request State, and hide PR-only sections and reviewer actions for branch evidence.
  - Added tests for branch context behavior, closeout rendering, and scoring.

<sup>Written for commit 4e6f81cf481b977e510768abc857acc66117acca. Summary will update on new commits. <a href="https://cubic.dev/pr/VilnaCRM-Org/bootstrap-infrastructure/pull/33?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

