### PR TITLE
[codex] Refine Well-Architected owner closeout actions

### DIFF
--- a/scripts/render_well_architected_closeout.py
+++ b/scripts/render_well_architected_closeout.py
@@ -376,6 +376,59 @@ def _reviewer_action_lines(pr_head: object) -> list[str]:
     ]
 
 
+def _failed_check(checks_by_name: dict[str, dict[str, Any]], check_name: str) -> bool:
+    check = checks_by_name.get(check_name, {})
+    status = check.get("status")
+    return status is not None and status not in NON_BLOCKING_CHECK_STATUSES
+
+
+def _vulnerability_owner_lines() -> list[str]:
+    return [
+        "### Vulnerability Owner",
+        "",
+        "- Prefer merging a default-branch dependency remediation that lands "
+        "the patched `uv.lock` for every open high-severity alert.",
+        "- If remediation cannot merge immediately, generate a short exception "
+        "with `make report-dependabot-exception` and re-run "
+        "`DEPENDABOT_EXCEPTION_EVIDENCE=<path> "
+        "make report-well-architected-evidence`.",
+        "",
+        _shell_template(
+            [
+                (
+                    "DEPENDABOT_EXCEPTION_OUTPUT",
+                    ".artifacts/well-architected/dependabot-exception.md",
+                ),
+                (
+                    "DEPENDABOT_EXCEPTION_JSON_OUTPUT",
+                    ".artifacts/well-architected/dependabot-exception.json",
+                ),
+                ("DEPENDABOT_EXCEPTION_REVIEWER", REVIEWER_LOGIN_PLACEHOLDER),
+                ("DEPENDABOT_EXCEPTION_OWNER", "<security-owner-login-or-team>"),
+                (
+                    "DEPENDABOT_EXCEPTION_APPROVAL",
+                    APPROVAL_DECISION_PLACEHOLDER,
+                ),
+                (
+                    "DEPENDABOT_EXCEPTION_REASON",
+                    "<non-secret reason alerts cannot close immediately>",
+                ),
+                (
+                    "DEPENDABOT_EXCEPTION_REMEDIATION",
+                    "<non-secret remediation plan and target>",
+                ),
+                ("DEPENDABOT_EXCEPTION_EXPIRY_DATE", DATE_PLACEHOLDER),
+                (
+                    "DEPENDABOT_EXCEPTION_EVIDENCE_NOTE",
+                    "<non-secret owner evidence reference>",
+                ),
+            ],
+            "report-dependabot-exception",
+        ),
+        "",
+    ]
+
+
 def render_closeout_bundle(
     evidence_report: dict[str, Any], question_verification: dict[str, Any]
 ) -> str:
@@ -409,6 +462,11 @@ def render_closeout_bundle(
     pr_head = pr_checks.get("headRefOid", "")
     reviewer_lines = (
         _reviewer_action_lines(pr_head) if evidence_report.get("pr") else []
+    )
+    vulnerability_owner_lines = (
+        _vulnerability_owner_lines()
+        if _failed_check(checks_by_name, "github_dependabot_alerts")
+        else []
     )
     final_collector_command = _collector_command(
         evidence_report.get("pr", ""),
@@ -579,48 +637,7 @@ def render_closeout_bundle(
             "- Re-run `SECURITY_ACCOUNT_ATTESTATION_EVIDENCE=<path> "
             "make report-well-architected-evidence`.",
             "",
-            "### Vulnerability Owner",
-            "",
-            "- Prefer merging a default-branch dependency remediation that lands "
-            "the patched `uv.lock` for every open high-severity alert.",
-            "- If remediation cannot merge immediately, generate a short exception "
-            "with `make report-dependabot-exception` and re-run "
-            "`DEPENDABOT_EXCEPTION_EVIDENCE=<path> "
-            "make report-well-architected-evidence`.",
-            "",
-            _shell_template(
-                [
-                    (
-                        "DEPENDABOT_EXCEPTION_OUTPUT",
-                        ".artifacts/well-architected/dependabot-exception.md",
-                    ),
-                    (
-                        "DEPENDABOT_EXCEPTION_JSON_OUTPUT",
-                        ".artifacts/well-architected/dependabot-exception.json",
-                    ),
-                    ("DEPENDABOT_EXCEPTION_REVIEWER", REVIEWER_LOGIN_PLACEHOLDER),
-                    ("DEPENDABOT_EXCEPTION_OWNER", "<security-owner-login-or-team>"),
-                    (
-                        "DEPENDABOT_EXCEPTION_APPROVAL",
-                        APPROVAL_DECISION_PLACEHOLDER,
-                    ),
-                    (
-                        "DEPENDABOT_EXCEPTION_REASON",
-                        "<non-secret reason alerts cannot close immediately>",
-                    ),
-                    (
-                        "DEPENDABOT_EXCEPTION_REMEDIATION",
-                        "<non-secret remediation plan and target>",
-                    ),
-                    ("DEPENDABOT_EXCEPTION_EXPIRY_DATE", DATE_PLACEHOLDER),
-                    (
-                        "DEPENDABOT_EXCEPTION_EVIDENCE_NOTE",
-                        "<non-secret owner evidence reference>",
-                    ),
-                ],
-                "report-dependabot-exception",
-            ),
-            "",
+            *vulnerability_owner_lines,
             "### SRE Owner",
             "",
             "- Generate monthly downstream alert-route evidence with "

--- a/tests/unit/test_script_entrypoints.py
+++ b/tests/unit/test_script_entrypoints.py
@@ -2630,6 +2630,12 @@ def test_render_well_architected_closeout_writes_owner_handoff(
                         ],
                     },
                     {
+                        "name": "github_dependabot_alerts",
+                        "status": "failed",
+                        "evidence": {"openAlertNumbers": [4]},
+                        "blockers": ["Dependabot alerts remain open."],
+                    },
+                    {
                         "name": "external_control_evidence",
                         "status": "failed",
                         "evidence": {
@@ -2814,6 +2820,7 @@ def test_render_well_architected_closeout_handles_clean_and_invalid_inputs(
     assert "Not applicable in this branch evidence context" in branch_text  # nosec B101
     assert "| PR head SHA |" not in branch_text  # nosec B101
     assert "### Reviewer" not in branch_text  # nosec B101
+    assert "### Vulnerability Owner" not in branch_text  # nosec B101
     assert "| Current final scores | None |" in text  # nosec B101
     assert "| Unresolved question IDs | None |" in text  # nosec B101
     assert "| Unresolved control IDs | None |" in text  # nosec B101


### PR DESCRIPTION
## Summary

- Show Vulnerability Owner handoff steps in the Well-Architected closeout bundle only when `github_dependabot_alerts` is actually failing.
- Keep Dependabot remediation guidance covered by tests for failing-alert scenarios.
- Keep current `main` branch closeout focused on the remaining real blockers: branch protection, `prod` environment, IAM/security attestation, OPS8/SRE evidence, and production DR owner evidence.

## Root Cause

After the default-branch Dependabot alerts were resolved, the generated closeout bundle still printed Vulnerability Owner steps unconditionally. That made the manual closeout list noisier than the actual collector blocker set.

## Validation

- `uv run ruff check scripts/render_well_architected_closeout.py tests/unit/test_script_entrypoints.py`
- `uv run pytest -q tests/unit/test_script_entrypoints.py` (`139 passed`)
- `git diff --check`
- `make report-well-architected-closeout`
- Downloaded hosted Well-Architected artifact from main run `25973802248` and verified current blockers match the local workflow-equivalent evidence.

## Remaining Manual Blockers

This is a closeout clarity patch only. Final #17 completion still requires repo/admin and owner evidence for #26, #27, #28, and #30.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Vulnerability Owner steps in the Well-Architected closeout only when `github_dependabot_alerts` is failing. This reduces noise so owners see just the real blockers.

- **Bug Fixes**
  - Conditionally render the Vulnerability Owner handoff using `_failed_check(checks_by_name, "github_dependabot_alerts")`.
  - Extracted `_vulnerability_owner_lines()` and added `_failed_check()` helper for clarity.
  - Updated tests to assert the section appears only when Dependabot alerts are open.

<sup>Written for commit a35905bb8b34b40ab3ad8f18d1e0a950c93d9228. Summary will update on new commits. <a href="https://cubic.dev/pr/VilnaCRM-Org/bootstrap-infrastructure/pull/34?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Vulnerability Owner" section now renders conditionally based on GitHub Dependabot alerts check status, appearing only when checks fail.

* **Tests**
  * Updated test fixtures to verify conditional section rendering in closeout bundles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VilnaCRM-Org/bootstrap-infrastructure/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->