### PR TITLE
[codex] Add PR comment Pulumi promotion

### DIFF
--- a/.github/workflows/pulumi-pr-command-runner.yml
+++ b/.github/workflows/pulumi-pr-command-runner.yml
@@ -1,0 +1,790 @@
+name: Pulumi PR Command Runner
+
+on:
+  repository_dispatch:
+    types:
+      - pulumi-pr-command
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Pull request number to operate on
+        required: true
+        type: string
+      head_sha:
+        description: Full PR head SHA to verify before running
+        required: true
+        type: string
+      target_environment:
+        description: Target environment
+        required: true
+        type: choice
+        options:
+          - test
+          - prod
+      command:
+        description: Pulumi command
+        required: true
+        type: choice
+        options:
+          - plan
+          - up
+
+concurrency:
+  group: >-
+    pulumi-pr-command-${{ github.event.client_payload.pull_request_number ||
+    inputs.pull_request_number }}-${{ github.event.client_payload.target_environment ||
+    inputs.target_environment }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      command: ${{ steps.resolve.outputs.command }}
+      display_command: ${{ steps.resolve.outputs.display_command }}
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+      pull_request_number: ${{ steps.resolve.outputs.pull_request_number }}
+      target_environment: ${{ steps.resolve.outputs.target_environment }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REQUEST_COMMAND: ${{ github.event.client_payload.command || inputs.command }}
+      REQUEST_HEAD_SHA: ${{ github.event.client_payload.head_sha || inputs.head_sha }}
+      REQUEST_PR_NUMBER: >-
+        ${{ github.event.client_payload.pull_request_number ||
+        inputs.pull_request_number }}
+      REQUEST_TARGET_ENVIRONMENT: >-
+        ${{ github.event.client_payload.target_environment ||
+        inputs.target_environment }}
+    steps:
+      - name: Resolve and verify pull request command
+        id: resolve
+        run: |
+          if [[ ! "${REQUEST_PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "error: pull_request_number must be numeric." >&2
+            exit 1
+          fi
+          if [[ ! "${REQUEST_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "error: head_sha must be a full lowercase 40-character commit SHA." >&2
+            exit 1
+          fi
+          if [[ "${REQUEST_TARGET_ENVIRONMENT}" != "test" && "${REQUEST_TARGET_ENVIRONMENT}" != "prod" ]]; then
+            echo "error: target_environment must be test or prod." >&2
+            exit 1
+          fi
+          if [[ "${REQUEST_COMMAND}" != "plan" && "${REQUEST_COMMAND}" != "up" ]]; then
+            echo "error: command must be plan or up." >&2
+            exit 1
+          fi
+
+          actual_head_sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${REQUEST_PR_NUMBER}" --jq '.head.sha')"
+          actual_head_repo="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${REQUEST_PR_NUMBER}" --jq '.head.repo.full_name')"
+          if [[ "${actual_head_repo}" != "${GITHUB_REPOSITORY}" ]]; then
+            gh pr comment "${REQUEST_PR_NUMBER}" --body "Pulumi PR command runner rejected this request because the pull request head is not in the base repository."
+            exit 1
+          fi
+          if [[ "${actual_head_sha}" != "${REQUEST_HEAD_SHA}" ]]; then
+            gh pr comment "${REQUEST_PR_NUMBER}" --body "Pulumi PR command runner rejected this request because the pull request head moved after the command was queued. Comment again on the latest commit."
+            exit 1
+          fi
+
+          {
+            echo "command=${REQUEST_COMMAND}"
+            echo "display_command=/pulumi ${REQUEST_TARGET_ENVIRONMENT} ${REQUEST_COMMAND}"
+            echo "head_sha=${REQUEST_HEAD_SHA}"
+            echo "pull_request_number=${REQUEST_PR_NUMBER}"
+            echo "target_environment=${REQUEST_TARGET_ENVIRONMENT}"
+          } >> "${GITHUB_OUTPUT}"
+
+  test_preview:
+    name: Test Preview
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+    timeout-minutes: 25
+    environment: test
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PULUMI_SKIP_UPDATE_CHECK: "true"
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_PREVIEW_ROLE_ARN: ${{ vars.AWS_PREVIEW_ROLE_ARN }}
+      PULUMI_BACKEND_URL: ${{ vars.PULUMI_BACKEND_URL || vars.PULUMI_PR_BACKEND_URL }}
+      PULUMI_SECRETS_PROVIDER: ${{ vars.PULUMI_SECRETS_PROVIDER }}
+      PULUMI_PREVIEW_STACKS: ${{ vars.PULUMI_PREVIEW_STACKS || vars.PULUMI_PR_PREVIEW_STACKS }}
+      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ needs.preflight.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Validate test preview prerequisites
+        run: |
+          missing=()
+          for name in \
+            AWS_ACCOUNT_ID \
+            AWS_PREVIEW_ROLE_ARN \
+            PULUMI_BACKEND_URL \
+            PULUMI_SECRETS_PROVIDER \
+            PULUMI_PREVIEW_STACKS; do
+            if [[ -z "${!name}" ]]; then
+              missing+=("${name}")
+            fi
+          done
+          if [[ "${#missing[@]}" -gt 0 ]]; then
+            printf 'error: PR test preview is missing %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+          if [[ ! "${AWS_ACCOUNT_ID}" =~ ^[0-9]{12}$ ]]; then
+            echo "error: AWS_ACCOUNT_ID must be a 12-digit AWS account ID." >&2
+            exit 1
+          fi
+          if [[ "${PULUMI_BACKEND_URL}" != s3://* ]]; then
+            echo "error: PULUMI_BACKEND_URL must use an s3:// backend." >&2
+            exit 1
+          fi
+          if [[ "${PULUMI_SECRETS_PROVIDER}" != awskms://* ]]; then
+            echo "error: PULUMI_SECRETS_PROVIDER must use an awskms:// URI." >&2
+            exit 1
+          fi
+
+      - name: Configure AWS preview credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
+          role-session-name: gha-pr-test-preview-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.AWS_ACCOUNT_ID }}
+
+      - name: Emit test preview evidence
+        run: |
+          account_id="$(aws sts get-caller-identity --query Account --output text)"
+          echo "GitHub environment: test"
+          echo "Commit SHA: ${{ needs.preflight.outputs.head_sha }}"
+          echo "AWS account ID: ${account_id}"
+          echo "Pulumi stacks: ${PULUMI_PREVIEW_STACKS}"
+          echo "Role purpose: preview"
+          echo "PR command: ${{ needs.preflight.outputs.display_command }}"
+
+      - name: Start development environment
+        run: make start
+
+      - name: Save test update plan and preview artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PULUMI_COMMIT_SHA: ${{ needs.preflight.outputs.head_sha }}
+        run: make pulumi-plan
+
+      - name: Upload test preview artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: >-
+            pr-command-${{ needs.preflight.outputs.pull_request_number }}-${{
+            needs.preflight.outputs.head_sha }}-test-preview
+          path: .artifacts/pulumi-preview
+          retention-days: 7
+
+      - name: Upload test plan artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: >-
+            pr-command-${{ needs.preflight.outputs.pull_request_number }}-${{
+            needs.preflight.outputs.head_sha }}-test-plan
+          path: .artifacts/pulumi-plan
+          retention-days: 7
+
+  test_destructive_diff:
+    name: Test Destructive Diff Gate
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - test_preview
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ needs.preflight.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Start development environment
+        run: make start
+
+      - name: Download test preview artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
+        with:
+          name: >-
+            pr-command-${{ needs.preflight.outputs.pull_request_number }}-${{
+            needs.preflight.outputs.head_sha }}-test-preview
+          path: .artifacts/pulumi-preview
+
+      - name: Stage pull request labels for destructive diff override
+        run: |
+          mkdir -p .artifacts
+          labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${{ needs.preflight.outputs.pull_request_number }}/labels" --jq '[.[] | {name: .name}]')"
+          printf '{"pull_request":{"labels":%s}}\n' "${labels}" > .artifacts/github-event.json
+
+      - name: Enforce destructive diff gate
+        run: make test-destructive-diff
+
+  test_iam_validation:
+    name: Test IAM Validation
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - test_preview
+      - test_destructive_diff
+    timeout-minutes: 15
+    environment: test
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PULUMI_SKIP_UPDATE_CHECK: "true"
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_PREVIEW_ROLE_ARN: ${{ vars.AWS_PREVIEW_ROLE_ARN }}
+      PULUMI_BACKEND_URL: ${{ vars.PULUMI_BACKEND_URL || vars.PULUMI_PR_BACKEND_URL }}
+      PULUMI_SECRETS_PROVIDER: ${{ vars.PULUMI_SECRETS_PROVIDER }}
+      PULUMI_PREVIEW_STACKS: ${{ vars.PULUMI_PREVIEW_STACKS || vars.PULUMI_PR_PREVIEW_STACKS }}
+      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ needs.preflight.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Configure AWS preview credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
+          role-session-name: gha-pr-test-iam-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.AWS_ACCOUNT_ID }}
+
+      - name: Start development environment
+        run: make start
+
+      - name: Download test preview artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
+        with:
+          name: >-
+            pr-command-${{ needs.preflight.outputs.pull_request_number }}-${{
+            needs.preflight.outputs.head_sha }}-test-preview
+          path: .artifacts/pulumi-preview
+
+      - name: Validate IAM policies
+        run: make test-iam-validation
+
+  test_apply:
+    name: Test Apply
+    if: >-
+      needs.preflight.outputs.target_environment == 'prod' ||
+      (needs.preflight.outputs.target_environment == 'test' &&
+      needs.preflight.outputs.command == 'up')
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - test_preview
+      - test_destructive_diff
+      - test_iam_validation
+    timeout-minutes: 30
+    environment: test
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PULUMI_SKIP_UPDATE_CHECK: "true"
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_APPLY_ROLE_ARN: ${{ vars.AWS_APPLY_ROLE_ARN || vars.AWS_PREVIEW_ROLE_ARN }}
+      PULUMI_BACKEND_URL: ${{ vars.PULUMI_BACKEND_URL || vars.PULUMI_PR_BACKEND_URL }}
+      PULUMI_SECRETS_PROVIDER: ${{ vars.PULUMI_SECRETS_PROVIDER }}
+      PULUMI_PREVIEW_STACKS: ${{ vars.PULUMI_PREVIEW_STACKS || vars.PULUMI_PR_PREVIEW_STACKS }}
+      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ needs.preflight.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Configure AWS apply credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: ${{ env.AWS_APPLY_ROLE_ARN }}
+          role-session-name: gha-pr-test-apply-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.AWS_ACCOUNT_ID }}
+
+      - name: Emit test apply evidence
+        run: |
+          account_id="$(aws sts get-caller-identity --query Account --output text)"
+          echo "GitHub environment: test"
+          echo "Commit SHA: ${{ needs.preflight.outputs.head_sha }}"
+          echo "AWS account ID: ${account_id}"
+          echo "Pulumi stacks: ${PULUMI_PREVIEW_STACKS}"
+          echo "Role purpose: apply"
+          echo "PR command: ${{ needs.preflight.outputs.display_command }}"
+
+      - name: Start development environment
+        run: make start
+
+      - name: Download test plan artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
+        with:
+          name: >-
+            pr-command-${{ needs.preflight.outputs.pull_request_number }}-${{
+            needs.preflight.outputs.head_sha }}-test-plan
+          path: .artifacts/pulumi-plan
+
+      - name: Apply saved test plan
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PULUMI_EXPECTED_SHA: ${{ needs.preflight.outputs.head_sha }}
+        run: |
+          set +e
+          make pulumi-up-plan 2>&1 | tee .artifacts/pulumi-plan/apply.log
+          apply_rc="${PIPESTATUS[0]}"
+          set -e
+          if [[ "${apply_rc}" -eq 0 ]]; then
+            exit 0
+          fi
+          if grep -Fq "decrypting secret value: cipher: message authentication failed" .artifacts/pulumi-plan/apply.log; then
+            echo "::warning::Saved Pulumi plan failed with the known KMS plan-decrypt error; retrying guarded direct test apply after preview, destructive diff, and IAM validation gates."
+            make pulumi-up
+            exit 0
+          fi
+          exit "${apply_rc}"
+
+  test_post_apply_drift:
+    name: Test Post-Apply Drift
+    if: >-
+      needs.preflight.outputs.target_environment == 'prod' ||
+      (needs.preflight.outputs.target_environment == 'test' &&
+      needs.preflight.outputs.command == 'up')
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - test_apply
+    timeout-minutes: 20
+    environment: test
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PULUMI_SKIP_UPDATE_CHECK: "true"
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_DRIFT_ROLE_ARN: ${{ vars.AWS_DRIFT_ROLE_ARN || vars.AWS_PREVIEW_ROLE_ARN }}
+      PULUMI_BACKEND_URL: ${{ vars.PULUMI_BACKEND_URL || vars.PULUMI_PR_BACKEND_URL }}
+      PULUMI_SECRETS_PROVIDER: ${{ vars.PULUMI_SECRETS_PROVIDER }}
+      PULUMI_DRIFT_STACKS: ${{ vars.PULUMI_DRIFT_STACKS || vars.PULUMI_PR_PREVIEW_STACKS }}
+      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ needs.preflight.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Configure AWS drift credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: ${{ env.AWS_DRIFT_ROLE_ARN }}
+          role-session-name: gha-pr-test-drift-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.AWS_ACCOUNT_ID }}
+
+      - name: Start development environment
+        run: make start
+
+      - name: Run test post-apply drift detection
+        run: make test-drift
+
+  prod_preview:
+    name: Prod Preview
+    if: >-
+      needs.preflight.outputs.target_environment == 'prod' &&
+      needs.test_post_apply_drift.result == 'success'
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - test_post_apply_drift
+    timeout-minutes: 25
+    environment: prod-preview
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PULUMI_SKIP_UPDATE_CHECK: "true"
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_PREVIEW_ROLE_ARN: ${{ vars.AWS_PREVIEW_ROLE_ARN }}
+      AWS_DRIFT_ROLE_ARN: ${{ vars.AWS_DRIFT_ROLE_ARN }}
+      PULUMI_BACKEND_URL: ${{ vars.PULUMI_BACKEND_URL }}
+      PULUMI_SECRETS_PROVIDER: ${{ vars.PULUMI_SECRETS_PROVIDER }}
+      PULUMI_PREVIEW_STACKS: ${{ vars.PULUMI_PREVIEW_STACKS }}
+      PULUMI_DRIFT_STACKS: ${{ vars.PULUMI_DRIFT_STACKS }}
+      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ needs.preflight.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Validate production preview prerequisites
+        run: |
+          missing=()
+          for name in \
+            AWS_ACCOUNT_ID \
+            AWS_PREVIEW_ROLE_ARN \
+            AWS_DRIFT_ROLE_ARN \
+            PULUMI_BACKEND_URL \
+            PULUMI_SECRETS_PROVIDER \
+            PULUMI_PREVIEW_STACKS \
+            PULUMI_DRIFT_STACKS; do
+            if [[ -z "${!name}" ]]; then
+              missing+=("${name}")
+            fi
+          done
+          if [[ "${#missing[@]}" -gt 0 ]]; then
+            printf 'error: PR production preview is missing %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+          if [[ ! "${AWS_ACCOUNT_ID}" =~ ^[0-9]{12}$ ]]; then
+            echo "error: AWS_ACCOUNT_ID must be a 12-digit AWS account ID." >&2
+            exit 1
+          fi
+          if [[ "${PULUMI_BACKEND_URL}" != s3://* ]]; then
+            echo "error: PULUMI_BACKEND_URL must use an s3:// backend." >&2
+            exit 1
+          fi
+          if [[ "${PULUMI_SECRETS_PROVIDER}" != awskms://* ]]; then
+            echo "error: PULUMI_SECRETS_PROVIDER must use an awskms:// URI." >&2
+            exit 1
+          fi
+
+      - name: Configure AWS preview credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
+          role-session-name: gha-pr-prod-preview-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.AWS_ACCOUNT_ID }}
+
+      - name: Emit production preview evidence
+        run: |
+          account_id="$(aws sts get-caller-identity --query Account --output text)"
+          echo "GitHub environment: prod-preview"
+          echo "Commit SHA: ${{ needs.preflight.outputs.head_sha }}"
+          echo "AWS account ID: ${account_id}"
+          echo "Pulumi stacks: ${PULUMI_PREVIEW_STACKS}"
+          echo "Role purpose: preview"
+          echo "PR command: ${{ needs.preflight.outputs.display_command }}"
+
+      - name: Start development environment
+        run: make start
+
+      - name: Save production update plan and preview artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PULUMI_COMMIT_SHA: ${{ needs.preflight.outputs.head_sha }}
+        run: make pulumi-plan
+
+      - name: Upload production preview artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: >-
+            pr-command-${{ needs.preflight.outputs.pull_request_number }}-${{
+            needs.preflight.outputs.head_sha }}-prod-preview
+          path: .artifacts/pulumi-preview
+          retention-days: 7
+
+      - name: Upload production plan artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: >-
+            pr-command-${{ needs.preflight.outputs.pull_request_number }}-${{
+            needs.preflight.outputs.head_sha }}-prod-plan
+          path: .artifacts/pulumi-plan
+          retention-days: 7
+
+  prod_destructive_diff:
+    name: Prod Destructive Diff Gate
+    if: needs.preflight.outputs.target_environment == 'prod'
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - prod_preview
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ needs.preflight.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Start development environment
+        run: make start
+
+      - name: Download production preview artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
+        with:
+          name: >-
+            pr-command-${{ needs.preflight.outputs.pull_request_number }}-${{
+            needs.preflight.outputs.head_sha }}-prod-preview
+          path: .artifacts/pulumi-preview
+
+      - name: Stage pull request labels for destructive diff override
+        run: |
+          mkdir -p .artifacts
+          labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${{ needs.preflight.outputs.pull_request_number }}/labels" --jq '[.[] | {name: .name}]')"
+          printf '{"pull_request":{"labels":%s}}\n' "${labels}" > .artifacts/github-event.json
+
+      - name: Enforce destructive diff gate
+        run: make test-destructive-diff
+
+  prod_iam_validation:
+    name: Prod IAM Validation
+    if: needs.preflight.outputs.target_environment == 'prod'
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - prod_preview
+      - prod_destructive_diff
+    timeout-minutes: 15
+    environment: prod-preview
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PULUMI_SKIP_UPDATE_CHECK: "true"
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_PREVIEW_ROLE_ARN: ${{ vars.AWS_PREVIEW_ROLE_ARN }}
+      PULUMI_BACKEND_URL: ${{ vars.PULUMI_BACKEND_URL }}
+      PULUMI_SECRETS_PROVIDER: ${{ vars.PULUMI_SECRETS_PROVIDER }}
+      PULUMI_PREVIEW_STACKS: ${{ vars.PULUMI_PREVIEW_STACKS }}
+      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ needs.preflight.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Configure AWS preview credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: ${{ env.AWS_PREVIEW_ROLE_ARN }}
+          role-session-name: gha-pr-prod-iam-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.AWS_ACCOUNT_ID }}
+
+      - name: Start development environment
+        run: make start
+
+      - name: Download production preview artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
+        with:
+          name: >-
+            pr-command-${{ needs.preflight.outputs.pull_request_number }}-${{
+            needs.preflight.outputs.head_sha }}-prod-preview
+          path: .artifacts/pulumi-preview
+
+      - name: Validate IAM policies
+        run: make test-iam-validation
+
+  prod_apply:
+    name: Prod Apply
+    if: >-
+      needs.preflight.outputs.target_environment == 'prod' &&
+      needs.preflight.outputs.command == 'up'
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - prod_preview
+      - prod_destructive_diff
+      - prod_iam_validation
+    timeout-minutes: 30
+    environment: prod
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PULUMI_SKIP_UPDATE_CHECK: "true"
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_APPLY_ROLE_ARN: ${{ vars.AWS_APPLY_ROLE_ARN }}
+      PULUMI_BACKEND_URL: ${{ vars.PULUMI_BACKEND_URL }}
+      PULUMI_SECRETS_PROVIDER: ${{ vars.PULUMI_SECRETS_PROVIDER }}
+      PULUMI_PREVIEW_STACKS: ${{ vars.PULUMI_PREVIEW_STACKS }}
+      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ needs.preflight.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Verify approved commit SHA
+        run: |
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [[ "${checked_out_sha}" != "${{ needs.preflight.outputs.head_sha }}" ]]; then
+            echo "error: approved workflow SHA does not match checked-out production SHA" >&2
+            exit 1
+          fi
+          echo "Approved production SHA: ${checked_out_sha}"
+
+      - name: Configure AWS apply credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: ${{ env.AWS_APPLY_ROLE_ARN }}
+          role-session-name: gha-pr-prod-apply-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.AWS_ACCOUNT_ID }}
+
+      - name: Emit production apply evidence
+        run: |
+          account_id="$(aws sts get-caller-identity --query Account --output text)"
+          echo "GitHub environment: prod"
+          echo "Commit SHA: ${{ needs.preflight.outputs.head_sha }}"
+          echo "AWS account ID: ${account_id}"
+          echo "Pulumi stacks: ${PULUMI_PREVIEW_STACKS}"
+          echo "Role purpose: apply"
+          echo "PR command: ${{ needs.preflight.outputs.display_command }}"
+
+      - name: Start development environment
+        run: make start
+
+      - name: Download production plan artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
+        with:
+          name: >-
+            pr-command-${{ needs.preflight.outputs.pull_request_number }}-${{
+            needs.preflight.outputs.head_sha }}-prod-plan
+          path: .artifacts/pulumi-plan
+
+      - name: Apply saved production plan
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PULUMI_EXPECTED_SHA: ${{ needs.preflight.outputs.head_sha }}
+        run: make pulumi-up-plan
+
+  prod_post_apply_drift:
+    name: Prod Post-Apply Drift
+    if: >-
+      needs.preflight.outputs.target_environment == 'prod' &&
+      needs.preflight.outputs.command == 'up'
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - prod_apply
+    timeout-minutes: 20
+    environment: prod-preview
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PULUMI_SKIP_UPDATE_CHECK: "true"
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_DEFAULT_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+      AWS_DRIFT_ROLE_ARN: ${{ vars.AWS_DRIFT_ROLE_ARN }}
+      PULUMI_BACKEND_URL: ${{ vars.PULUMI_BACKEND_URL }}
+      PULUMI_SECRETS_PROVIDER: ${{ vars.PULUMI_SECRETS_PROVIDER }}
+      PULUMI_DRIFT_STACKS: ${{ vars.PULUMI_DRIFT_STACKS }}
+      PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ needs.preflight.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Configure AWS drift credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: ${{ env.AWS_DRIFT_ROLE_ARN }}
+          role-session-name: gha-pr-prod-drift-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.AWS_ACCOUNT_ID }}
+
+      - name: Start development environment
+        run: make start
+
+      - name: Run production post-apply drift detection
+        run: make test-drift
+
+  comment_result:
+    name: Comment Result
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - test_preview
+      - test_destructive_diff
+      - test_iam_validation
+      - test_apply
+      - test_post_apply_drift
+      - prod_preview
+      - prod_destructive_diff
+      - prod_iam_validation
+      - prod_apply
+      - prod_post_apply_drift
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Post PR command result
+        run: |
+          body_file="$(mktemp)"
+          {
+            echo "## Pulumi PR command result"
+            echo
+            echo "- Command: \`${{ needs.preflight.outputs.display_command || 'preflight' }}\`"
+            echo "- Commit: \`${{ needs.preflight.outputs.head_sha || 'unknown' }}\`"
+            echo "- Workflow run: ${RUN_URL}"
+            echo
+            echo "| Stage | Result |"
+            echo "| --- | --- |"
+            echo "| Preflight | \`${{ needs.preflight.result }}\` |"
+            echo "| Test preview | \`${{ needs.test_preview.result }}\` |"
+            echo "| Test destructive diff | \`${{ needs.test_destructive_diff.result }}\` |"
+            echo "| Test IAM validation | \`${{ needs.test_iam_validation.result }}\` |"
+            echo "| Test apply | \`${{ needs.test_apply.result }}\` |"
+            echo "| Test post-apply drift | \`${{ needs.test_post_apply_drift.result }}\` |"
+            echo "| Production preview | \`${{ needs.prod_preview.result }}\` |"
+            echo "| Production destructive diff | \`${{ needs.prod_destructive_diff.result }}\` |"
+            echo "| Production IAM validation | \`${{ needs.prod_iam_validation.result }}\` |"
+            echo "| Production apply | \`${{ needs.prod_apply.result }}\` |"
+            echo "| Production post-apply drift | \`${{ needs.prod_post_apply_drift.result }}\` |"
+            echo
+            echo "Production stages are gated behind a successful test apply and test post-apply drift check for the same PR head SHA."
+          } > "${body_file}"
+
+          pr_number="${{ needs.preflight.outputs.pull_request_number }}"
+          if [[ -n "${pr_number}" ]]; then
+            gh pr comment "${pr_number}" --body-file "${body_file}"
+          else
+            cat "${body_file}"
+          fi

--- a/.github/workflows/pulumi-pr-command-runner.yml
+++ b/.github/workflows/pulumi-pr-command-runner.yml
@@ -89,6 +89,12 @@ jobs:
 
           actual_head_sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${REQUEST_PR_NUMBER}" --jq '.head.sha')"
           actual_head_repo="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${REQUEST_PR_NUMBER}" --jq '.head.repo.full_name')"
+          actual_pr_state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${REQUEST_PR_NUMBER}" --jq '.state')"
+          actual_pr_merged="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${REQUEST_PR_NUMBER}" --jq '.merged')"
+          if [[ "${actual_pr_state}" != "open" || "${actual_pr_merged}" == "true" ]]; then
+            gh pr comment "${REQUEST_PR_NUMBER}" --body "Pulumi PR command runner rejected this request because the pull request is closed or merged."
+            exit 1
+          fi
           if [[ "${actual_head_repo}" != "${GITHUB_REPOSITORY}" ]]; then
             gh pr comment "${REQUEST_PR_NUMBER}" --body "Pulumi PR command runner rejected this request because the pull request head is not in the base repository."
             exit 1

--- a/.github/workflows/pulumi-pr-command-runner.yml
+++ b/.github/workflows/pulumi-pr-command-runner.yml
@@ -87,10 +87,11 @@ jobs:
             exit 1
           fi
 
-          actual_head_sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${REQUEST_PR_NUMBER}" --jq '.head.sha')"
-          actual_head_repo="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${REQUEST_PR_NUMBER}" --jq '.head.repo.full_name')"
-          actual_pr_state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${REQUEST_PR_NUMBER}" --jq '.state')"
-          actual_pr_merged="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${REQUEST_PR_NUMBER}" --jq '.merged')"
+          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${REQUEST_PR_NUMBER}")"
+          actual_head_sha="$(jq -r '.head.sha' <<< "${pr_json}")"
+          actual_head_repo="$(jq -r '.head.repo.full_name' <<< "${pr_json}")"
+          actual_pr_state="$(jq -r '.state' <<< "${pr_json}")"
+          actual_pr_merged="$(jq -r '.merged' <<< "${pr_json}")"
           if [[ "${actual_pr_state}" != "open" || "${actual_pr_merged}" == "true" ]]; then
             gh pr comment "${REQUEST_PR_NUMBER}" --body "Pulumi PR command runner rejected this request because the pull request is closed or merged."
             exit 1

--- a/.github/workflows/pulumi-pr-commands.yml
+++ b/.github/workflows/pulumi-pr-commands.yml
@@ -21,7 +21,9 @@ permissions:
 jobs:
   dispatch:
     name: Dispatch PR Command
-    if: github.event.issue.pull_request != null
+    if: >-
+      github.event.issue.pull_request != null &&
+      github.event.issue.state == 'open'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -64,12 +66,25 @@ jobs:
           {
             echo "head_sha=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
             echo "head_repo=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name')"
+            echo "state=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state')"
+            echo "merged=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.merged')"
           } >> "${GITHUB_OUTPUT}"
+
+      - name: Reject closed or merged pull requests
+        if: >-
+          steps.parse.outputs.skip != 'true' &&
+          steps.parse.outputs.authorized == 'true' &&
+          (steps.pr.outputs.state != 'open' || steps.pr.outputs.merged == 'true')
+        run: |
+          gh pr comment "${{ github.event.issue.number }}" \
+            --body "Pulumi PR commands are only accepted while the pull request is open and unmerged."
 
       - name: Reject forked pull requests
         if: >-
           steps.parse.outputs.skip != 'true' &&
           steps.parse.outputs.authorized == 'true' &&
+          steps.pr.outputs.state == 'open' &&
+          steps.pr.outputs.merged == 'false' &&
           steps.pr.outputs.head_repo != github.repository
         run: |
           body_file="$(mktemp)"
@@ -83,6 +98,8 @@ jobs:
         if: >-
           steps.parse.outputs.skip != 'true' &&
           steps.parse.outputs.authorized == 'true' &&
+          steps.pr.outputs.state == 'open' &&
+          steps.pr.outputs.merged == 'false' &&
           steps.pr.outputs.head_repo == github.repository
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
@@ -106,6 +123,8 @@ jobs:
         if: >-
           steps.parse.outputs.skip != 'true' &&
           steps.parse.outputs.authorized == 'true' &&
+          steps.pr.outputs.state == 'open' &&
+          steps.pr.outputs.merged == 'false' &&
           steps.pr.outputs.head_repo == github.repository
         run: |
           body_file="$(mktemp)"

--- a/.github/workflows/pulumi-pr-commands.yml
+++ b/.github/workflows/pulumi-pr-commands.yml
@@ -1,0 +1,117 @@
+name: Pulumi PR Commands
+
+on:
+  issue_comment:
+    types:
+      - created
+
+concurrency:
+  group: pulumi-pr-command-intake-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  dispatch:
+    name: Dispatch PR Command
+    if: github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Parse Pulumi command
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_ASSOCIATION: ${{ github.event.comment.author_association }}
+        run: |
+          python ./scripts/pulumi_pr_comment.py \
+            "${COMMENT_BODY}" \
+            --author-association "${COMMENT_ASSOCIATION}"
+
+      - name: Ignore non-Pulumi comments
+        if: steps.parse.outputs.skip == 'true'
+        run: echo "Skipping non-Pulumi PR comment."
+
+      - name: Reject unauthorized requester
+        if: >-
+          steps.parse.outputs.skip != 'true' &&
+          steps.parse.outputs.authorized != 'true'
+        run: |
+          gh pr comment "${{ github.event.issue.number }}" \
+            --body "Pulumi PR commands are restricted to repository owners, members, and collaborators."
+
+      - name: Resolve pull request metadata
+        if: >-
+          steps.parse.outputs.skip != 'true' &&
+          steps.parse.outputs.authorized == 'true'
+        id: pr
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          {
+            echo "head_sha=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+            echo "head_repo=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name')"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Reject forked pull requests
+        if: >-
+          steps.parse.outputs.skip != 'true' &&
+          steps.parse.outputs.authorized == 'true' &&
+          steps.pr.outputs.head_repo != github.repository
+        run: |
+          body_file="$(mktemp)"
+          cat > "${body_file}" <<'EOF'
+          Pulumi PR commands are only enabled for branches in this repository.
+          Forked pull requests are rejected to avoid exposing AWS credentials.
+          EOF
+          gh pr comment "${{ github.event.issue.number }}" --body-file "${body_file}"
+
+      - name: Dispatch trusted runner
+        if: >-
+          steps.parse.outputs.skip != 'true' &&
+          steps.parse.outputs.authorized == 'true' &&
+          steps.pr.outputs.head_repo == github.repository
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          TARGET_ENVIRONMENT: ${{ steps.parse.outputs.target_environment }}
+          PULUMI_COMMAND: ${{ steps.parse.outputs.command }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f event_type='pulumi-pr-command' \
+            -f "client_payload[pull_request_number]=${PR_NUMBER}" \
+            -f "client_payload[head_sha]=${HEAD_SHA}" \
+            -f "client_payload[target_environment]=${TARGET_ENVIRONMENT}" \
+            -f "client_payload[command]=${PULUMI_COMMAND}" \
+            -f "client_payload[comment_id]=${COMMENT_ID}"
+
+      - name: Comment queued command
+        if: >-
+          steps.parse.outputs.skip != 'true' &&
+          steps.parse.outputs.authorized == 'true' &&
+          steps.pr.outputs.head_repo == github.repository
+        run: |
+          body_file="$(mktemp)"
+          {
+            echo "Queued \`${{ steps.parse.outputs.display_command }}\` for \`${{ steps.pr.outputs.head_sha }}\`."
+            echo
+            echo "A trusted runner workflow will re-check the PR head SHA before using AWS credentials."
+          } > "${body_file}"
+          gh pr comment "${{ github.event.issue.number }}" --body-file "${body_file}"

--- a/.github/workflows/pulumi-pr-commands.yml
+++ b/.github/workflows/pulumi-pr-commands.yml
@@ -63,11 +63,12 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
+          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
           {
-            echo "head_sha=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
-            echo "head_repo=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name')"
-            echo "state=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state')"
-            echo "merged=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.merged')"
+            echo "head_sha=$(jq -r '.head.sha' <<< "${pr_json}")"
+            echo "head_repo=$(jq -r '.head.repo.full_name' <<< "${pr_json}")"
+            echo "state=$(jq -r '.state' <<< "${pr_json}")"
+            echo "merged=$(jq -r '.merged' <<< "${pr_json}")"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Reject closed or merged pull requests

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,6 +137,10 @@ CI checks are split into focused workflows that run inside the Docker workspace:
 - `security-scans.yml` runs secrets, Bandit, dependency audit/review, workflow linting, YAML linting, and Hadolint.
 - `bats-tests.yml` validates the Makefile CLI surface.
 - `pulumi-local.yml` runs `make ci-pr`, the non-mutation pull-request battery inside Docker.
+- `pulumi-pr-commands.yml` accepts trusted same-repository PR comments for Pulumi plan/apply requests.
+- `pulumi-pr-command-runner.yml` revalidates the PR SHA, runs test account plan/guardrails/apply first, and gates production promotion behind the successful test sequence.
+- `pulumi-test-deploy.yml` plans, validates, applies, and drift-checks the test account on `main`.
+- `pulumi-prod.yml` requires a successful test deployment for the requested SHA before production preview, approval, saved-plan apply, and drift.
 - `nightly-quality.yml` publishes maintainability, dead-code, docstring, and SBOM reports.
 
 These checks do not require AWS or Pulumi credentials by default. They use
@@ -149,6 +153,9 @@ Privileged issue 18 workflows use GitHub environments for account separation:
 production preview and drift; and protected `prod` for production apply.
 Configure account-local variables, OIDC roles, Pulumi backend URLs, and AWS
 KMS-backed Pulumi secrets providers in the [GitHub Actions Secrets guide](github-actions-secrets.md).
+The PR-comment path accepts `/pulumi test plan`, `/pulumi test up`,
+`/pulumi prod plan`, and `/pulumi prod up`; production comments run the test
+account apply and post-apply drift gates successfully before production starts.
 
 ## CI Quality Gates
 

--- a/docs/ci-architecture.md
+++ b/docs/ci-architecture.md
@@ -18,6 +18,8 @@ Docker-backed pull request checks use the same Docker workspace and the same
 | `pulumi-structural.yml` | `make test-pulumi`, `make test-repository-catalogs`, `make test-repository-fanout` | Validates Pulumi metadata, workflow contracts, repository catalogs, static fanout, and Dockerfile safeguards |
 | `pulumi-policy.yml` | `make test-policy` | Validates the Pulumi policy pack and AWS guardrail coverage |
 | `pulumi-pr-guardrails.yml` | `make publish-pulumi-preview-summary`, `make test-preview-unprivileged`, `make test-destructive-diff`, `make test-iam-validation` | Generates the PR preview artifact and enforces destructive/IAM guardrails without giving fork PRs AWS credentials |
+| `pulumi-pr-commands.yml` | `scripts/pulumi_pr_comment.py`, `repository_dispatch` | Parses trusted PR comments, rejects forked PRs, and queues exact-SHA Pulumi operations |
+| `pulumi-pr-command-runner.yml` | `make pulumi-plan`, destructive diff, IAM validation, apply, drift | Executes PR-comment Pulumi commands with test-first production promotion gates |
 | `pulumi-test-deploy.yml` | `make pulumi-plan`, destructive diff, IAM validation, apply, drift | Applies the `test` stack after main merges or manual dispatch |
 | `pulumi-prod.yml` | test-deploy SHA check, `make pulumi-plan`, approval, apply | Previews with `prod-preview`, then applies through protected `prod` |
 | `security-scans.yml` | `make test-secrets`, `make test-deps-security`, `make test-bandit`, `make test-actionlint`, `make test-yaml`, `make test-dockerfile` | Runs blocking security and repo-hygiene checks plus GitHub dependency review |
@@ -52,6 +54,14 @@ first verifies that the requested commit already has a successful `Pulumi Test
 Deploy` run on `main`, then records sanitized evidence for the reviewed commit.
 The apply job runs only in the protected `prod` environment after required
 reviewers approve it and the commit SHA is still the reviewed SHA.
+
+PR-comment production promotion follows the same account boundaries, but the
+trusted runner performs the test sequence inside the command workflow before
+any production job can start. `/pulumi prod plan` and `/pulumi prod up` both
+save and validate a test plan, apply it to the `test` account, and run
+post-apply drift detection for the exact PR head SHA. Only after that succeeds
+does the runner enter `prod-preview`; `/pulumi prod up` then waits on the
+protected `prod` environment and applies the saved production plan.
 
 ## Shared Controls
 

--- a/docs/github-actions-secrets.md
+++ b/docs/github-actions-secrets.md
@@ -1,9 +1,9 @@
 # GitHub Actions Secrets and Variables
 
 The hardened CI/CD layer in this repository is OIDC-first. Preview, IAM
-validation, and nightly drift detection are designed to use short-lived AWS
-credentials issued through GitHub Actions OIDC. Do not add long-lived static AWS
-access keys for these workflows.
+validation, PR-comment plan/apply commands, and nightly drift detection are
+designed to use short-lived AWS credentials issued through GitHub Actions OIDC.
+Do not add long-lived static AWS access keys for these workflows.
 
 ## GitHub environments
 
@@ -14,8 +14,8 @@ under **Settings -> Environments**:
 
 | Environment | Purpose | Protection |
 | --- | --- | --- |
-| `test` | Trusted PR previews, merge-to-main test applies, and test drift checks | No production approval; keep branch scope limited to protected branches for apply jobs |
-| `prod-preview` | Production previews and production drift checks with read-only or preview-only AWS access | No apply permissions |
+| `test` | Trusted PR previews, PR-comment test commands, merge-to-main test applies, and test drift checks | No production approval; keep branch scope limited to protected branches for apply jobs |
+| `prod-preview` | PR-comment production plans, production previews, and production drift checks with read-only or preview-only AWS access | No apply permissions |
 | `prod` | Production apply only | Require reviewers and restrict deployment branches |
 
 Fork pull requests must stay unprivileged. Same-repo privileged jobs should fail
@@ -31,8 +31,9 @@ differs between test and production.
 | --- | --- | --- |
 | `AWS_ACCOUNT_ID` | Expected 12-digit AWS account ID for the environment | Used with OIDC account allow-listing and evidence |
 | `AWS_REGION` | Region used by `configure-aws-credentials` and Pulumi | Optional only when the workflow has a safe default |
-| `AWS_PREVIEW_ROLE_ARN` | OIDC role used by preview, IAM validation, and drift jobs | Required for `test` and `prod-preview` |
+| `AWS_PREVIEW_ROLE_ARN` | OIDC role used by preview and IAM validation jobs | Required for `test` and `prod-preview` |
 | `AWS_APPLY_ROLE_ARN` | OIDC role used by apply jobs | Required only for `test` and `prod` |
+| `AWS_DRIFT_ROLE_ARN` | OIDC role used by drift jobs | Required for `prod-preview`; `test` can fall back to `AWS_PREVIEW_ROLE_ARN` |
 | `AWS_OPERATIONS_ALERT_TRIAGE_ROLE_ARN` | Dedicated OIDC role used only by operations alert issue triage | Required for `test` when alert triage is enabled |
 | `PULUMI_BACKEND_URL` | Account-specific shared Pulumi backend | Required for privileged jobs |
 | `PULUMI_SECRETS_PROVIDER` | AWS KMS Pulumi secrets provider URI | Required; use an `awskms://...` URI |
@@ -54,6 +55,29 @@ Use separate AWS roles per account and purpose. Preview roles should be unable
 to mutate production resources. Apply roles should be scoped to the exact
 resources Pulumi manages in that account.
 
+## PR comment commands
+
+Repository owners, members, and collaborators can request Pulumi operations from
+same-repository pull requests:
+
+```text
+/pulumi test plan
+/pulumi test up
+/pulumi prod plan
+/pulumi prod up
+```
+
+`/pulumi plan` and `/pulumi up` are compatibility aliases for the `test`
+environment. Fork pull requests are rejected before any AWS credentials are
+requested.
+
+The comment intake workflow dispatches a trusted runner with the PR number,
+exact head SHA, target environment, and command. The runner revalidates that the
+PR head is still the queued SHA before checkout. Production commands always run
+the test account first: they save and validate a test plan, apply it to `test`,
+run post-apply drift detection, and only then continue to `prod-preview` or the
+protected `prod` environment for the same SHA.
+
 ## Optional environment secrets
 
 Add these under the GitHub environment's **Secrets** tab only when needed.
@@ -68,9 +92,9 @@ than a passphrase-managed stack secret flow.
 ## OIDC role setup
 
 1. Create an IAM OIDC identity provider for `https://token.actions.githubusercontent.com` in each AWS account if it does not already exist.
-2. Create separate preview, apply, and operations alert triage roles where the environment needs them.
+2. Create separate preview, apply, drift, and operations alert triage roles where the environment needs them.
 3. Scope trust policies to this repository, the `sts.amazonaws.com` audience, and the relevant GitHub environment subject.
-4. Store the role ARNs as `AWS_PREVIEW_ROLE_ARN`, `AWS_APPLY_ROLE_ARN`, or `AWS_OPERATIONS_ALERT_TRIAGE_ROLE_ARN` in the matching GitHub environment.
+4. Store the role ARNs as `AWS_PREVIEW_ROLE_ARN`, `AWS_APPLY_ROLE_ARN`, `AWS_DRIFT_ROLE_ARN`, or `AWS_OPERATIONS_ALERT_TRIAGE_ROLE_ARN` in the matching GitHub environment.
 5. Configure workflows to use `allowed-account-ids` with `AWS_ACCOUNT_ID`.
 
 See the dedicated [CI guardrails guide](ci-guardrails.md) for an example trust policy and the documented `sub` claim formats.

--- a/scripts/pulumi_pr_comment.py
+++ b/scripts/pulumi_pr_comment.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+AUTHORIZED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+PULUMI_ACTIONS = frozenset({"plan", "up"})
+PULUMI_ENVIRONMENTS = frozenset({"test", "prod"})
+
+
+@dataclass(frozen=True)
+class PulumiPrCommand:
+    target_environment: str
+    action: str
+
+    @property
+    def display_command(self) -> str:
+        return f"/pulumi {self.target_environment} {self.action}"
+
+
+def parse_command(body: str) -> PulumiPrCommand | None:
+    tokens = body.strip().lower().split()
+    if not tokens or tokens[0] not in {"/pulumi", "pulumi"}:
+        return None
+
+    args = tokens[1:]
+    if len(args) == 1 and args[0] in PULUMI_ACTIONS:
+        return PulumiPrCommand(target_environment="test", action=args[0])
+
+    if len(args) == 2:
+        first, second = args
+        if first in PULUMI_ENVIRONMENTS and second in PULUMI_ACTIONS:
+            return PulumiPrCommand(target_environment=first, action=second)
+        if first in PULUMI_ACTIONS and second in PULUMI_ENVIRONMENTS:
+            return PulumiPrCommand(target_environment=second, action=first)
+
+    return None
+
+
+def author_is_authorized(author_association: str) -> bool:
+    return author_association.strip().upper() in AUTHORIZED_ASSOCIATIONS
+
+
+def build_outputs(
+    command: PulumiPrCommand | None, author_association: str
+) -> dict[str, str]:
+    outputs = {
+        "authorized": "true" if author_is_authorized(author_association) else "false"
+    }
+    if command is None:
+        return {**outputs, "skip": "true"}
+
+    return {
+        **outputs,
+        "skip": "false",
+        "target_environment": command.target_environment,
+        "command": command.action,
+        "display_command": command.display_command,
+    }
+
+
+def render_outputs(outputs: dict[str, str]) -> str:
+    return "".join(f"{key}={value}\n" for key, value in outputs.items())
+
+
+def write_outputs(outputs: dict[str, str], output_path: str | None) -> None:
+    rendered = render_outputs(outputs)
+    print(rendered, end="")
+    if output_path:
+        with Path(output_path).open("a", encoding="utf-8") as handle:
+            handle.write(rendered)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Parse trusted Pulumi pull-request comment commands."
+    )
+    parser.add_argument("body")
+    parser.add_argument("--author-association", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    outputs = build_outputs(parse_command(args.body), args.author_association)
+    write_outputs(outputs, os.environ.get("GITHUB_OUTPUT"))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/specs/pr-comment-pulumi-promotion/architecture.md
+++ b/specs/pr-comment-pulumi-promotion/architecture.md
@@ -21,7 +21,9 @@
 - The issue-comment workflow does not check out PR code.
 - AWS credentials exist only in the trusted runner jobs bound to GitHub
   environments.
-- Each OIDC job uses the purpose-specific environment role: preview, apply, or
-  drift.
-- Production jobs are impossible unless the same runner has already completed
-  test apply and test post-apply drift successfully.
+- Each OIDC job uses the environment role configured for its stage: preview,
+  apply, or drift, with apply/drift optionally falling back to the preview role
+  when dedicated role variables are not set.
+- Production jobs are impossible unless the same workflow run has already
+  completed test apply and test post-apply drift successfully for that PR head
+  SHA.

--- a/specs/pr-comment-pulumi-promotion/architecture.md
+++ b/specs/pr-comment-pulumi-promotion/architecture.md
@@ -1,0 +1,27 @@
+# PR Comment Pulumi Promotion Architecture
+
+## Flow
+
+1. `pulumi-pr-commands.yml` runs on `issue_comment.created`.
+2. `scripts/pulumi_pr_comment.py` parses the comment and author association.
+3. The intake workflow rejects unauthorized authors and fork pull requests.
+4. The intake workflow sends `repository_dispatch` with PR number, head SHA,
+   target environment, command, and comment ID.
+5. `pulumi-pr-command-runner.yml` revalidates the PR head repository and SHA.
+6. The runner saves a test plan with `make pulumi-plan`, then runs destructive
+   diff and IAM validation against the uploaded preview artifact.
+7. `test up` applies the saved test plan and runs drift detection.
+8. Production commands also apply and drift-check test first, then enter
+   `prod-preview` for the production plan and guardrails.
+9. `prod up` enters the protected `prod` environment and applies only the saved
+   production plan with `make pulumi-up-plan`.
+
+## Safety Boundaries
+
+- The issue-comment workflow does not check out PR code.
+- AWS credentials exist only in the trusted runner jobs bound to GitHub
+  environments.
+- Each OIDC job uses the purpose-specific environment role: preview, apply, or
+  drift.
+- Production jobs are impossible unless the same runner has already completed
+  test apply and test post-apply drift successfully.

--- a/specs/pr-comment-pulumi-promotion/implementation-readiness-report.md
+++ b/specs/pr-comment-pulumi-promotion/implementation-readiness-report.md
@@ -1,0 +1,26 @@
+# PR Comment Pulumi Promotion Readiness
+
+## BMALPH Status
+
+`bmalph status -C .` and `bmalph doctor -C .` show this repository is not
+initialized for generated BMALPH/Ralph framework state. `bmalph init --dry-run`
+would create `_bmad/`, `bmalph/`, `.ralph/`, and `.agents/skills/` files, which
+the repository instructions explicitly keep out of committed planning changes.
+The canonical planning artifacts for this feature therefore live under
+`specs/pr-comment-pulumi-promotion/`.
+
+## Implementation Plan
+
+- Add a tested Python comment parser.
+- Add a comment intake workflow that dispatches trusted exact-SHA commands.
+- Add a repository-dispatch runner with test-first production sequencing.
+- Extend structural workflow tests and OIDC role-contract tests.
+- Update docs for PR comment commands and required environment variables.
+
+## Verification Plan
+
+- `uv run pytest -q tests/unit/test_pulumi_pr_comment.py`
+- `uv run pytest -q tests/pulumi/test_delivery_contracts.py`
+- `make test-repo-hygiene`
+- `make test-pulumi`
+- `make test-unit`

--- a/specs/pr-comment-pulumi-promotion/prd.md
+++ b/specs/pr-comment-pulumi-promotion/prd.md
@@ -1,0 +1,36 @@
+# PR Comment Pulumi Promotion PRD
+
+## Problem
+
+Maintainers need a GitHub-native way to run Pulumi `plan` and `up` for pull
+request infrastructure changes without manually copying SHAs into separate
+workflows. Production promotion must prove the same PR head SHA was applied and
+drift-checked in the test account first.
+
+## Goals
+
+- Accept explicit PR comments for test and production Pulumi operations.
+- Reject fork pull requests before any AWS credentials are requested.
+- Re-check the queued PR head SHA immediately before checkout.
+- Run production commands only after the test account plan, guardrails, apply,
+  and post-apply drift checks succeed for the same SHA.
+- Keep production apply saved-plan-only and protected by the `prod` GitHub
+  environment.
+
+## Non-Goals
+
+- Do not make fork pull requests privileged.
+- Do not bypass existing destructive diff, IAM validation, saved-plan, or drift
+  guardrails.
+- Do not commit generated BMALPH or BMAD framework state.
+
+## Acceptance Criteria
+
+- `/pulumi test plan`, `/pulumi test up`, `/pulumi prod plan`, and
+  `/pulumi prod up` are parsed deterministically.
+- `/pulumi plan` and `/pulumi up` continue to mean the test environment.
+- The comment workflow dispatches only exact PR head SHAs.
+- Production plan/apply jobs depend on successful test apply and test
+  post-apply drift jobs.
+- Tests cover the parser, workflow trigger, SHA revalidation, same-repository
+  guard, environment-scoped OIDC jobs, and production saved-plan-only apply.

--- a/tests/pulumi/test_delivery_contracts.py
+++ b/tests/pulumi/test_delivery_contracts.py
@@ -907,6 +907,7 @@ def test_pr_comment_workflows_gate_prod_after_successful_test_apply() -> None:
     prod_apply_lines = "\n".join(_run_lines(runner["jobs"]["prod_apply"]["steps"]))
 
     assert _triggers(intake)["issue_comment"]["types"] == ["created"]  # nosec B101
+    assert "github.event.issue.state == 'open'" in intake["jobs"]["dispatch"]["if"]  # nosec B101
     assert intake["permissions"] == {  # nosec B101
         "contents": "write",
         "issues": "write",
@@ -916,6 +917,8 @@ def test_pr_comment_workflows_gate_prod_after_successful_test_apply() -> None:
     assert "event_type='pulumi-pr-command'" in intake_lines  # nosec B101
     assert "client_payload[head_sha]" in intake_lines  # nosec B101
     assert "head_repo == github.repository" in str(intake)  # nosec B101
+    assert "state == 'open'" in str(intake)  # nosec B101
+    assert "merged == 'false'" in str(intake)  # nosec B101
 
     triggers = _triggers(runner)
     assert triggers["repository_dispatch"]["types"] == ["pulumi-pr-command"]  # nosec B101
@@ -932,6 +935,8 @@ def test_pr_comment_workflows_gate_prod_after_successful_test_apply() -> None:
     )
     assert "actual_head_sha" in preflight_lines  # nosec B101
     assert "actual_head_repo" in preflight_lines  # nosec B101
+    assert "actual_pr_state" in preflight_lines  # nosec B101
+    assert "pull request is closed or merged" in preflight_lines  # nosec B101
     assert "pull request head moved after the command was queued" in preflight_lines  # nosec B101
 
     prod_preview = runner["jobs"]["prod_preview"]

--- a/tests/pulumi/test_delivery_contracts.py
+++ b/tests/pulumi/test_delivery_contracts.py
@@ -914,6 +914,10 @@ def test_pr_comment_workflows_gate_prod_after_successful_test_apply() -> None:
         "pull-requests": "read",
     }
     assert "scripts/pulumi_pr_comment.py" in intake_lines  # nosec B101
+    assert (
+        intake_lines.count('gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"')
+        == 1
+    )  # nosec B101
     assert "event_type='pulumi-pr-command'" in intake_lines  # nosec B101
     assert "client_payload[head_sha]" in intake_lines  # nosec B101
     assert "head_repo == github.repository" in str(intake)  # nosec B101
@@ -936,6 +940,12 @@ def test_pr_comment_workflows_gate_prod_after_successful_test_apply() -> None:
     assert "actual_head_sha" in preflight_lines  # nosec B101
     assert "actual_head_repo" in preflight_lines  # nosec B101
     assert "actual_pr_state" in preflight_lines  # nosec B101
+    assert (
+        preflight_lines.count(
+            'gh api "repos/${GITHUB_REPOSITORY}/pulls/${REQUEST_PR_NUMBER}"'
+        )
+        == 1
+    )  # nosec B101
     assert "pull request is closed or merged" in preflight_lines  # nosec B101
     assert "pull request head moved after the command was queued" in preflight_lines  # nosec B101
 

--- a/tests/pulumi/test_delivery_contracts.py
+++ b/tests/pulumi/test_delivery_contracts.py
@@ -725,6 +725,29 @@ def test_multi_account_workflows_use_environment_scoped_oidc_contracts() -> None
             "test",
             alert_triage_role,
         ),
+        ("pulumi-pr-command-runner.yml", "test_preview"): ("test", preview_role),
+        ("pulumi-pr-command-runner.yml", "test_iam_validation"): (
+            "test",
+            preview_role,
+        ),
+        ("pulumi-pr-command-runner.yml", "test_apply"): ("test", apply_role),
+        ("pulumi-pr-command-runner.yml", "test_post_apply_drift"): (
+            "test",
+            drift_role,
+        ),
+        ("pulumi-pr-command-runner.yml", "prod_preview"): (
+            "prod-preview",
+            preview_role,
+        ),
+        ("pulumi-pr-command-runner.yml", "prod_iam_validation"): (
+            "prod-preview",
+            preview_role,
+        ),
+        ("pulumi-pr-command-runner.yml", "prod_apply"): ("prod", apply_role),
+        ("pulumi-pr-command-runner.yml", "prod_post_apply_drift"): (
+            "prod-preview",
+            drift_role,
+        ),
         ("pulumi-pr-guardrails.yml", "preview"): ("test", preview_role),
         ("pulumi-pr-guardrails.yml", "iam_validation"): ("test", preview_role),
         ("pulumi-prod.yml", "preview"): ("prod-preview", preview_role),
@@ -868,6 +891,90 @@ def test_prod_workflow_requires_successful_test_deploy_for_same_sha() -> None:
     assert not re.search(r"(?m)^\s*make pulumi-up$", prod_apply_lines)  # nosec B101
     assert "make publish-pulumi-preview-summary" not in prod_preview_lines  # nosec B101
     assert "make publish-pulumi-preview-summary" not in test_preview_lines  # nosec B101
+
+
+def test_pr_comment_workflows_gate_prod_after_successful_test_apply() -> None:
+    """PR comments must run through test before production can plan or apply."""
+    intake = yaml.safe_load(
+        (WORKFLOWS_DIR / "pulumi-pr-commands.yml").read_text(encoding="utf-8")
+    )
+    runner = yaml.safe_load(
+        (WORKFLOWS_DIR / "pulumi-pr-command-runner.yml").read_text(encoding="utf-8")
+    )
+    intake_lines = "\n".join(_run_lines(intake["jobs"]["dispatch"]["steps"]))
+    preflight_lines = "\n".join(_run_lines(runner["jobs"]["preflight"]["steps"]))
+    test_apply_lines = "\n".join(_run_lines(runner["jobs"]["test_apply"]["steps"]))
+    prod_apply_lines = "\n".join(_run_lines(runner["jobs"]["prod_apply"]["steps"]))
+
+    assert _triggers(intake)["issue_comment"]["types"] == ["created"]  # nosec B101
+    assert intake["permissions"] == {  # nosec B101
+        "contents": "write",
+        "issues": "write",
+        "pull-requests": "read",
+    }
+    assert "scripts/pulumi_pr_comment.py" in intake_lines  # nosec B101
+    assert "event_type='pulumi-pr-command'" in intake_lines  # nosec B101
+    assert "client_payload[head_sha]" in intake_lines  # nosec B101
+    assert "head_repo == github.repository" in str(intake)  # nosec B101
+
+    triggers = _triggers(runner)
+    assert triggers["repository_dispatch"]["types"] == ["pulumi-pr-command"]  # nosec B101
+    assert "workflow_dispatch" in triggers  # nosec B101
+    assert runner["concurrency"]["cancel-in-progress"] is False  # nosec B101
+    assert runner["permissions"] == {  # nosec B101
+        "contents": "read",
+        "issues": "write",
+        "pull-requests": "read",
+    }
+
+    assert "head_sha must be a full lowercase 40-character commit SHA" in (  # nosec B101
+        preflight_lines
+    )
+    assert "actual_head_sha" in preflight_lines  # nosec B101
+    assert "actual_head_repo" in preflight_lines  # nosec B101
+    assert "pull request head moved after the command was queued" in preflight_lines  # nosec B101
+
+    prod_preview = runner["jobs"]["prod_preview"]
+    assert prod_preview["needs"] == ["preflight", "test_post_apply_drift"]  # nosec B101
+    assert (
+        "needs.test_post_apply_drift.result == 'success'"
+        in (  # nosec B101
+            prod_preview["if"]
+        )
+    )
+
+    assert "make pulumi-plan" in "\n".join(  # nosec B101
+        _run_lines(runner["jobs"]["test_preview"]["steps"])
+    )
+    assert "make test-destructive-diff" in "\n".join(  # nosec B101
+        _run_lines(runner["jobs"]["test_destructive_diff"]["steps"])
+    )
+    assert "make test-iam-validation" in "\n".join(  # nosec B101
+        _run_lines(runner["jobs"]["test_iam_validation"]["steps"])
+    )
+    assert "make pulumi-up-plan" in test_apply_lines  # nosec B101
+    assert "decrypting secret value: cipher: message authentication failed" in (  # nosec B101
+        test_apply_lines
+    )
+    assert re.search(r"(?m)^\s*make pulumi-up$", test_apply_lines)  # nosec B101
+    assert "make test-drift" in "\n".join(  # nosec B101
+        _run_lines(runner["jobs"]["test_post_apply_drift"]["steps"])
+    )
+
+    assert "make pulumi-plan" in "\n".join(  # nosec B101
+        _run_lines(runner["jobs"]["prod_preview"]["steps"])
+    )
+    assert "make test-destructive-diff" in "\n".join(  # nosec B101
+        _run_lines(runner["jobs"]["prod_destructive_diff"]["steps"])
+    )
+    assert "make test-iam-validation" in "\n".join(  # nosec B101
+        _run_lines(runner["jobs"]["prod_iam_validation"]["steps"])
+    )
+    assert "make pulumi-up-plan" in prod_apply_lines  # nosec B101
+    assert not re.search(r"(?m)^\s*make pulumi-up$", prod_apply_lines)  # nosec B101
+    assert "make test-drift" in "\n".join(  # nosec B101
+        _run_lines(runner["jobs"]["prod_post_apply_drift"]["steps"])
+    )
 
 
 def test_multi_account_environment_docs_are_explicit() -> None:

--- a/tests/unit/test_pulumi_pr_comment.py
+++ b/tests/unit/test_pulumi_pr_comment.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+pulumi_pr_comment = importlib.import_module("pulumi_pr_comment")
+
+
+def test_parse_command_accepts_canonical_and_compatibility_forms() -> None:
+    assert pulumi_pr_comment.parse_command("/pulumi test plan") == (
+        pulumi_pr_comment.PulumiPrCommand("test", "plan")
+    )
+    assert pulumi_pr_comment.parse_command("pulumi PROD UP") == (
+        pulumi_pr_comment.PulumiPrCommand("prod", "up")
+    )
+    assert pulumi_pr_comment.parse_command("/pulumi plan prod") == (
+        pulumi_pr_comment.PulumiPrCommand("prod", "plan")
+    )
+    assert pulumi_pr_comment.parse_command("pulumi up") == (
+        pulumi_pr_comment.PulumiPrCommand("test", "up")
+    )
+
+
+def test_parse_command_rejects_non_exact_or_unsafe_forms() -> None:
+    for body in (
+        "",
+        "hello",
+        "/pulumi",
+        "/pulumi destroy",
+        "/pulumi staging plan",
+        "/pulumi prod refresh",
+        "/pulumi prod up now",
+        "/pulumi; prod up",
+    ):
+        assert pulumi_pr_comment.parse_command(body) is None
+
+
+def test_authorization_uses_github_author_association() -> None:
+    for association in ("OWNER", "member", " Collaborator "):
+        assert pulumi_pr_comment.author_is_authorized(association) is True
+
+    for association in ("CONTRIBUTOR", "NONE", ""):
+        assert pulumi_pr_comment.author_is_authorized(association) is False
+
+
+def test_build_outputs_marks_skipped_and_actionable_comments() -> None:
+    skipped = pulumi_pr_comment.build_outputs(None, "CONTRIBUTOR")
+    command = pulumi_pr_comment.PulumiPrCommand("prod", "up")
+    actionable = pulumi_pr_comment.build_outputs(command, "MEMBER")
+
+    assert skipped == {"authorized": "false", "skip": "true"}
+    assert actionable == {
+        "authorized": "true",
+        "skip": "false",
+        "target_environment": "prod",
+        "command": "up",
+        "display_command": "/pulumi prod up",
+    }
+
+
+def test_write_outputs_prints_and_appends_github_outputs(
+    capsys, tmp_path: Path
+) -> None:
+    output_file = tmp_path / "github-output"
+    outputs = {"skip": "false", "command": "plan"}
+
+    pulumi_pr_comment.write_outputs(outputs, None)
+    pulumi_pr_comment.write_outputs(outputs, str(output_file))
+
+    expected = "skip=false\ncommand=plan\n"
+    assert capsys.readouterr().out == expected * 2
+    assert output_file.read_text(encoding="utf-8") == expected
+
+
+def test_main_parses_comment_and_uses_github_output(
+    monkeypatch, tmp_path: Path
+) -> None:
+    output_file = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    assert (
+        pulumi_pr_comment.main(["/pulumi prod plan", "--author-association", "OWNER"])
+        == 0
+    )
+
+    assert output_file.read_text(encoding="utf-8") == (
+        "authorized=true\n"
+        "skip=false\n"
+        "target_environment=prod\n"
+        "command=plan\n"
+        "display_command=/pulumi prod plan\n"
+    )


### PR DESCRIPTION
## Summary
- add `/pulumi test|prod plan|up` PR comment intake with exact-SHA repository dispatch
- add trusted runner workflow that applies/drift-checks test before any production preview/apply
- cover parser, OIDC role contracts, same-repo/SHA guards, and production saved-plan-only apply with tests
- document required GitHub environments, role variables, and BMALPH/BMAD planning artifacts

## Verification
- `python3 scripts/pulumi_pr_comment.py '/pulumi prod up' --author-association MEMBER`
- `python3 scripts/pulumi_pr_comment.py '/pulumi destroy' --author-association OWNER`
- `python3 scripts/pulumi_pr_comment.py '/pulumi test plan' --author-association CONTRIBUTOR`
- `uv run --frozen --no-sync pytest -q tests/unit/test_pulumi_pr_comment.py`
- `uv run --frozen --no-sync pytest -q tests/pulumi/test_delivery_contracts.py`
- `uv run --frozen --no-sync pytest -q tests/pulumi`
- `uv run --frozen --no-sync ruff check scripts/pulumi_pr_comment.py tests/unit/test_pulumi_pr_comment.py tests/pulumi/test_delivery_contracts.py`
- `uv run --frozen --no-sync ruff format --check scripts/pulumi_pr_comment.py tests/unit/test_pulumi_pr_comment.py tests/pulumi/test_delivery_contracts.py`
- `make test-repo-hygiene`
- `make test-unit`
- `make test-pulumi`
- `make test-cli`
- `make ci-pr-unprivileged`
- `make test-secrets`

## BMALPH/BMAD
- Ran `bmalph status -C .`, `bmalph doctor -C .`, and `bmalph init --platform codex --dry-run`.
- Did not commit generated BMALPH/Ralph framework state because repo instructions keep those files out of committed planning changes.
- Added feature planning artifacts under `specs/pr-comment-pulumi-promotion/`.

## Manual rollout note
The new `issue_comment` intake workflow only becomes active for real PR comments after it exists on the default branch. The runner also supports `workflow_dispatch` on this branch for controlled validation with the PR number and exact head SHA, subject to the configured GitHub environments and AWS OIDC roles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds trusted PR comment commands for Pulumi plan and apply with exact-SHA verification, test-first gates, and rejection of closed/merged or forked PRs. The intake now snapshots PR metadata (SHA, state, head repo) before validation to prevent races; the runner re-checks the same metadata before any AWS access.

- **New Features**
  - Accepts `/pulumi test plan|up` and `/pulumi prod plan|up`; `/pulumi plan|up` default to test.
  - Limits to OWNER/MEMBER/COLLABORATOR on same-repo PRs; rejects forks and closed/merged PRs.
  - Intake parses the comment, snapshots PR metadata, and dispatches PR number, exact head SHA, env, and command; runner preflight re-verifies open state, same repo, and exact SHA.
  - Test flow: save plan, destructive diff + IAM validation, apply saved plan (guarded direct apply fallback for the known KMS decrypt issue), then post-apply drift.
  - Prod flow: allowed only after the same SHA completes test apply + drift; `prod-preview` saves plan, `prod up` applies the saved plan in protected `prod`.

- **Migration**
  - Create GitHub environments: `test`, `prod-preview`, `prod` (protect `prod` with required reviewers).
  - Configure environment vars/secrets per docs: AWS account/region, `AWS_PREVIEW_ROLE_ARN`/`AWS_APPLY_ROLE_ARN`/`AWS_DRIFT_ROLE_ARN`, `PULUMI_BACKEND_URL`, `PULUMI_SECRETS_PROVIDER`, stack lists, and `PULUMI_ACCESS_TOKEN`; use OIDC with `allowed-account-ids`.
  - Merge to the default branch to activate `issue_comment`; `workflow_dispatch` supports manual runs with PR number and exact head SHA.

<sup>Written for commit 3c274a028f4516c910995c5daa2fdca3f6040544. Summary will update on new commits. <a href="https://cubic.dev/pr/VilnaCRM-Org/bootstrap-infrastructure/pull/44?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

