### PR TITLE
test(ci): exercise PR comment Pulumi promotion

### DIFF
--- a/.github/workflows/pulumi-pr-command-runner.yml
+++ b/.github/workflows/pulumi-pr-command-runner.yml
@@ -70,6 +70,16 @@ jobs:
       - name: Resolve and verify pull request command
         id: resolve
         run: |
+          post_pr_comment() {
+            local pr_number="$1"
+            local body="$2"
+            jq -n --arg body "${body}" '{body: $body}' \
+              | gh api \
+                --method POST \
+                "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
+                --input -
+          }
+
           if [[ ! "${REQUEST_PR_NUMBER}" =~ ^[0-9]+$ ]]; then
             echo "error: pull_request_number must be numeric." >&2
             exit 1
@@ -93,15 +103,15 @@ jobs:
           actual_pr_state="$(jq -r '.state' <<< "${pr_json}")"
           actual_pr_merged="$(jq -r '.merged' <<< "${pr_json}")"
           if [[ "${actual_pr_state}" != "open" || "${actual_pr_merged}" == "true" ]]; then
-            gh pr comment "${REQUEST_PR_NUMBER}" --body "Pulumi PR command runner rejected this request because the pull request is closed or merged."
+            post_pr_comment "${REQUEST_PR_NUMBER}" "Pulumi PR command runner rejected this request because the pull request is closed or merged."
             exit 1
           fi
           if [[ "${actual_head_repo}" != "${GITHUB_REPOSITORY}" ]]; then
-            gh pr comment "${REQUEST_PR_NUMBER}" --body "Pulumi PR command runner rejected this request because the pull request head is not in the base repository."
+            post_pr_comment "${REQUEST_PR_NUMBER}" "Pulumi PR command runner rejected this request because the pull request head is not in the base repository."
             exit 1
           fi
           if [[ "${actual_head_sha}" != "${REQUEST_HEAD_SHA}" ]]; then
-            gh pr comment "${REQUEST_PR_NUMBER}" --body "Pulumi PR command runner rejected this request because the pull request head moved after the command was queued. Comment again on the latest commit."
+            post_pr_comment "${REQUEST_PR_NUMBER}" "Pulumi PR command runner rejected this request because the pull request head moved after the command was queued. Comment again on the latest commit."
             exit 1
           fi
 
@@ -791,7 +801,11 @@ jobs:
 
           pr_number="${{ needs.preflight.outputs.pull_request_number }}"
           if [[ -n "${pr_number}" ]]; then
-            gh pr comment "${pr_number}" --body-file "${body_file}"
+            jq -Rs '{body: .}' < "${body_file}" \
+              | gh api \
+                --method POST \
+                "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
+                --input -
           else
             cat "${body_file}"
           fi

--- a/.github/workflows/pulumi-pr-commands.yml
+++ b/.github/workflows/pulumi-pr-commands.yml
@@ -52,8 +52,13 @@ jobs:
           steps.parse.outputs.skip != 'true' &&
           steps.parse.outputs.authorized != 'true'
         run: |
-          gh pr comment "${{ github.event.issue.number }}" \
-            --body "Pulumi PR commands are restricted to repository owners, members, and collaborators."
+          jq -n \
+            --arg body "Pulumi PR commands are restricted to repository owners, members, and collaborators." \
+            '{body: $body}' \
+            | gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${{ github.event.issue.number }}/comments" \
+              --input -
 
       - name: Resolve pull request metadata
         if: >-
@@ -77,8 +82,13 @@ jobs:
           steps.parse.outputs.authorized == 'true' &&
           (steps.pr.outputs.state != 'open' || steps.pr.outputs.merged == 'true')
         run: |
-          gh pr comment "${{ github.event.issue.number }}" \
-            --body "Pulumi PR commands are only accepted while the pull request is open and unmerged."
+          jq -n \
+            --arg body "Pulumi PR commands are only accepted while the pull request is open and unmerged." \
+            '{body: $body}' \
+            | gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${{ github.event.issue.number }}/comments" \
+              --input -
 
       - name: Reject forked pull requests
         if: >-
@@ -93,7 +103,11 @@ jobs:
           Pulumi PR commands are only enabled for branches in this repository.
           Forked pull requests are rejected to avoid exposing AWS credentials.
           EOF
-          gh pr comment "${{ github.event.issue.number }}" --body-file "${body_file}"
+          jq -Rs '{body: .}' < "${body_file}" \
+            | gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${{ github.event.issue.number }}/comments" \
+              --input -
 
       - name: Dispatch trusted runner
         if: >-
@@ -134,4 +148,8 @@ jobs:
             echo
             echo "A trusted runner workflow will re-check the PR head SHA before using AWS credentials."
           } > "${body_file}"
-          gh pr comment "${{ github.event.issue.number }}" --body-file "${body_file}"
+          jq -Rs '{body: .}' < "${body_file}" \
+            | gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${{ github.event.issue.number }}/comments" \
+              --input -

--- a/specs/pr-comment-pulumi-promotion/manual-qa-2026-05-17.md
+++ b/specs/pr-comment-pulumi-promotion/manual-qa-2026-05-17.md
@@ -1,0 +1,16 @@
+# Manual QA 2026-05-17
+
+This branch exists to exercise the PR-comment Pulumi promotion workflow after the
+workflow files are available on the default branch.
+
+The QA sequence is:
+
+1. Open a same-repository pull request from this branch.
+2. Comment `/pulumi test plan`.
+3. After it succeeds, comment `/pulumi test up`.
+4. After the test apply and drift check succeed, comment `/pulumi prod plan`.
+5. After production preview gates succeed, comment `/pulumi prod up`.
+
+The file intentionally does not change Pulumi resources; the QA run validates the
+comment parser, trusted dispatch, exact SHA checkout, OIDC-bound preview/apply
+jobs, saved-plan usage, drift checks, and production environment approval path.

--- a/tests/pulumi/test_delivery_contracts.py
+++ b/tests/pulumi/test_delivery_contracts.py
@@ -903,6 +903,9 @@ def test_pr_comment_workflows_gate_prod_after_successful_test_apply() -> None:
     )
     intake_lines = "\n".join(_run_lines(intake["jobs"]["dispatch"]["steps"]))
     preflight_lines = "\n".join(_run_lines(runner["jobs"]["preflight"]["steps"]))
+    comment_result_lines = "\n".join(
+        _run_lines(runner["jobs"]["comment_result"]["steps"])
+    )
     test_apply_lines = "\n".join(_run_lines(runner["jobs"]["test_apply"]["steps"]))
     prod_apply_lines = "\n".join(_run_lines(runner["jobs"]["prod_apply"]["steps"]))
 
@@ -920,6 +923,8 @@ def test_pr_comment_workflows_gate_prod_after_successful_test_apply() -> None:
     )  # nosec B101
     assert "event_type='pulumi-pr-command'" in intake_lines  # nosec B101
     assert "client_payload[head_sha]" in intake_lines  # nosec B101
+    assert "gh pr comment" not in intake_lines  # nosec B101
+    assert "/issues/${{ github.event.issue.number }}/comments" in intake_lines  # nosec B101
     assert "head_repo == github.repository" in str(intake)  # nosec B101
     assert "state == 'open'" in str(intake)  # nosec B101
     assert "merged == 'false'" in str(intake)  # nosec B101
@@ -946,6 +951,10 @@ def test_pr_comment_workflows_gate_prod_after_successful_test_apply() -> None:
         )
         == 1
     )  # nosec B101
+    assert "gh pr comment" not in preflight_lines  # nosec B101
+    assert "/issues/${pr_number}/comments" in preflight_lines  # nosec B101
+    assert "gh pr comment" not in comment_result_lines  # nosec B101
+    assert "/issues/${pr_number}/comments" in comment_result_lines  # nosec B101
     assert "pull request is closed or merged" in preflight_lines  # nosec B101
     assert "pull request head moved after the command was queued" in preflight_lines  # nosec B101
 


### PR DESCRIPTION
Manual QA PR for the merged PR-comment Pulumi promotion workflow.\n\nThis intentionally changes only a planning artifact so the live /pulumi test and prod command sequence can verify GitHub comment dispatch, exact-SHA checkout, OIDC jobs, saved-plan apply, drift checks, and production environment approval without introducing a resource change solely for testing.\n\nQA sequence:\n- /pulumi test plan\n- /pulumi test up\n- /pulumi prod plan\n- /pulumi prod up

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a planning-only spec to exercise the PR-comment Pulumi promotion workflow without changing resources.
Switches PR comment posting to the GitHub Issues comments API via `gh api` (replacing `gh pr comment`) and updates tests, while keeping end-to-end QA of /pulumi test/prod plan/up, comment parsing, trusted dispatch, exact-SHA checkout, OIDC-bound jobs, saved-plan apply, drift checks, and production approval gates.

<sup>Written for commit 3cb928957d37a7ced111111250c363a0a9b3b722. Summary will update on new commits. <a href="https://cubic.dev/pr/VilnaCRM-Org/bootstrap-infrastructure/pull/45?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

