### PR TITLE
test(ci): run live PR comment Pulumi QA

### DIFF
--- a/.github/workflows/pulumi-pr-command-runner.yml
+++ b/.github/workflows/pulumi-pr-command-runner.yml
@@ -43,7 +43,7 @@ defaults:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   preflight:

--- a/.github/workflows/pulumi-pr-command-runner.yml
+++ b/.github/workflows/pulumi-pr-command-runner.yml
@@ -42,14 +42,19 @@ defaults:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
+  issues: read
+  pull-requests: read
 
 jobs:
   preflight:
     name: Preflight
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      issues: write
+      # Rejection feedback is posted to the PR conversation; live QA showed
+      # GitHub rejects this with only issues: write on the Actions token.
+      pull-requests: write
     outputs:
       command: ${{ steps.resolve.outputs.command }}
       display_command: ${{ steps.resolve.outputs.display_command }}
@@ -768,6 +773,11 @@ jobs:
       - prod_apply
       - prod_post_apply_drift
     timeout-minutes: 10
+    permissions:
+      issues: write
+      # Result feedback is posted to the PR conversation; live QA showed
+      # GitHub rejects this with only issues: write on the Actions token.
+      pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/pulumi-pr-commands.yml
+++ b/.github/workflows/pulumi-pr-commands.yml
@@ -16,7 +16,7 @@ defaults:
 permissions:
   contents: write
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   dispatch:
@@ -26,6 +26,12 @@ jobs:
       github.event.issue.state == 'open'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      issues: write
+      # GitHub returns 403 for PR conversation comments from this workflow
+      # without pull-requests: write, even when issues: write is present.
+      pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/pulumi-pr-commands.yml
+++ b/.github/workflows/pulumi-pr-commands.yml
@@ -16,7 +16,7 @@ defaults:
 permissions:
   contents: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   dispatch:

--- a/specs/pr-comment-pulumi-promotion/manual-qa-2026-05-17.md
+++ b/specs/pr-comment-pulumi-promotion/manual-qa-2026-05-17.md
@@ -14,3 +14,8 @@ The QA sequence is:
 The file intentionally does not change Pulumi resources; the QA run validates the
 comment parser, trusted dispatch, exact SHA checkout, OIDC-bound preview/apply
 jobs, saved-plan usage, drift checks, and production environment approval path.
+
+## Live QA Attempt 2
+
+This update creates a fresh same-repository pull request after the issue-comment
+posting fix is present on `main`.

--- a/tests/pulumi/test_delivery_contracts.py
+++ b/tests/pulumi/test_delivery_contracts.py
@@ -914,7 +914,7 @@ def test_pr_comment_workflows_gate_prod_after_successful_test_apply() -> None:
     assert intake["permissions"] == {  # nosec B101
         "contents": "write",
         "issues": "write",
-        "pull-requests": "read",
+        "pull-requests": "write",
     }
     assert "scripts/pulumi_pr_comment.py" in intake_lines  # nosec B101
     assert (
@@ -936,7 +936,7 @@ def test_pr_comment_workflows_gate_prod_after_successful_test_apply() -> None:
     assert runner["permissions"] == {  # nosec B101
         "contents": "read",
         "issues": "write",
-        "pull-requests": "read",
+        "pull-requests": "write",
     }
 
     assert "head_sha must be a full lowercase 40-character commit SHA" in (  # nosec B101

--- a/tests/pulumi/test_delivery_contracts.py
+++ b/tests/pulumi/test_delivery_contracts.py
@@ -914,6 +914,11 @@ def test_pr_comment_workflows_gate_prod_after_successful_test_apply() -> None:
     assert intake["permissions"] == {  # nosec B101
         "contents": "write",
         "issues": "write",
+        "pull-requests": "read",
+    }
+    assert intake["jobs"]["dispatch"]["permissions"] == {  # nosec B101
+        "contents": "write",
+        "issues": "write",
         "pull-requests": "write",
     }
     assert "scripts/pulumi_pr_comment.py" in intake_lines  # nosec B101
@@ -935,6 +940,14 @@ def test_pr_comment_workflows_gate_prod_after_successful_test_apply() -> None:
     assert runner["concurrency"]["cancel-in-progress"] is False  # nosec B101
     assert runner["permissions"] == {  # nosec B101
         "contents": "read",
+        "issues": "read",
+        "pull-requests": "read",
+    }
+    assert runner["jobs"]["preflight"]["permissions"] == {  # nosec B101
+        "issues": "write",
+        "pull-requests": "write",
+    }
+    assert runner["jobs"]["comment_result"]["permissions"] == {  # nosec B101
         "issues": "write",
         "pull-requests": "write",
     }


### PR DESCRIPTION
Fresh manual QA PR after the PR-comment feedback fix landed on main.\n\nThe branch changes only a planning artifact so /pulumi commands exercise the real GitHub Actions and AWS paths without introducing a resource change solely for testing.\n\nSequential QA commands to run here:\n- /pulumi test plan\n- /pulumi test up\n- /pulumi prod plan\n- /pulumi prod up

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs a second live QA of the PR comment-driven Pulumi workflow after the issue-comment fix on `main`. Narrows permissions so PR comments work: adds `pull-requests: write` to the dispatch workflow and to `preflight`/`comment_result` jobs, sets top-level `issues` to read, and updates tests; no resource changes.

QA commands to run:
- /pulumi test plan
- /pulumi test up
- /pulumi prod plan
- /pulumi prod up

<sup>Written for commit c7cdbe409e77e3cef201fa79d4877c37953af114. Summary will update on new commits. <a href="https://cubic.dev/pr/VilnaCRM-Org/bootstrap-infrastructure/pull/46?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Live QA Attempt 2" note to the manual QA runbook describing the new QA step.

* **Chores**
  * Hardened CI workflow permissions by narrowing default token scopes while granting explicit job-level rights so PR-related comments continue to be posted.

* **Tests**
  * Updated permission-related tests to match the new CI permission expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VilnaCRM-Org/bootstrap-infrastructure/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->