### PR TITLE
feat(iam): Claude read-only role for secure AI-native AWS access

### DIFF
--- a/.claude/hooks/aws-readonly-guard.sh
+++ b/.claude/hooks/aws-readonly-guard.sh
@@ -22,16 +22,21 @@ if printf '%s' "$CMD" | grep -Eiq '(--profile[= ]+[^ ]*prod|AWS_PROFILE=[^ ]*pro
   deny "Blocked: prod AWS profile is out of scope for this read-only workspace. Run prod reads in a separate, MFA-gated session."
 fi
 
+# Match `aws` as a real command token: at the start, or preceded by any
+# non-identifier char. This catches chaining (`; aws`, `| aws`), wrappers with
+# intervening flags (`timeout 5 aws`, `xargs -I{} aws`), and full paths
+# (`/usr/bin/aws`), while ignoring substrings like `myaws`.
+AWS_TOKEN='(^|[^[:alnum:]_-])aws[[:space:]]'
+
 # Block mutating AWS CLI verbs (covers chained/compound commands the
 # permission glob matcher can miss).
 AWS_MUTATING='(create|delete|put|update|modify|remove|attach|detach|associate|disassociate|run-instances|terminate|reboot|deploy|invoke|reset|enable|disable|tag-resource|untag-resource|authorize-|revoke-|s3[[:space:]]+(rm|cp|mv|sync|rb))'
-if printf '%s' "$CMD" | grep -Eiq "(^|[;&|]|\bxargs |\btimeout )[[:space:]]*aws[[:space:]]" \
-  && printf '%s' "$CMD" | grep -Eiq "aws[[:space:]].*($AWS_MUTATING)"; then
+if printf '%s' "$CMD" | grep -Eiq "${AWS_TOKEN}.*($AWS_MUTATING)"; then
   deny "Blocked: AWS mutating command detected. This workspace is read-only. If a change is truly intended, run it from a session with write credentials against the right account."
 fi
 
 # Block AWS read actions that return secrets/credentials in plaintext.
-if printf '%s' "$CMD" | grep -Eiq 'aws[[:space:]].*(secretsmanager[[:space:]]+get-secret-value|kms[[:space:]]+decrypt|get-password-data|get-session-token|(ssm[[:space:]]+get-parameter))'; then
+if printf '%s' "$CMD" | grep -Eiq "${AWS_TOKEN}.*(secretsmanager[[:space:]]+get-secret-value|kms[[:space:]]+decrypt|get-password-data|get-session-token|(ssm[[:space:]]+get-parameter))"; then
   deny "Blocked: command reads secret/credential material. The read-only role denies these; do not attempt to exfiltrate secrets."
 fi
 

--- a/.claude/hooks/aws-readonly-guard.sh
+++ b/.claude/hooks/aws-readonly-guard.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PreToolUse guard: block obvious AWS/Pulumi/Terraform mutations as
+# defense-in-depth. This is NOT a security boundary -- the read-only IAM role
+# (ClaudeReadOnly-*, secret reads explicitly denied) is. A determined bypass
+# (env indirection, wrappers, unusual spacing) defeats a regex over shell text;
+# the IAM credentials are what actually hold.
+set -euo pipefail
+
+INPUT="$(cat)"
+CMD="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')"
+
+[ -z "$CMD" ] && exit 0
+
+deny() {
+  jq -n --arg reason "$1" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
+  exit 0
+}
+
+# Never let the agent target a prod profile from this read-only workspace.
+if printf '%s' "$CMD" | grep -Eiq '(--profile[= ]+[^ ]*prod|AWS_PROFILE=[^ ]*prod)'; then
+  deny "Blocked: prod AWS profile is out of scope for this read-only workspace. Run prod reads in a separate, MFA-gated session."
+fi
+
+# Block mutating AWS CLI verbs (covers chained/compound commands the
+# permission glob matcher can miss).
+AWS_MUTATING='(create|delete|put|update|modify|remove|attach|detach|associate|disassociate|run-instances|terminate|reboot|deploy|invoke|reset|enable|disable|tag-resource|untag-resource|authorize-|revoke-|s3[[:space:]]+(rm|cp|mv|sync|rb))'
+if printf '%s' "$CMD" | grep -Eiq "(^|[;&|]|\bxargs |\btimeout )[[:space:]]*aws[[:space:]]" \
+  && printf '%s' "$CMD" | grep -Eiq "aws[[:space:]].*($AWS_MUTATING)"; then
+  deny "Blocked: AWS mutating command detected. This workspace is read-only. If a change is truly intended, run it from a session with write credentials against the right account."
+fi
+
+# Block AWS read actions that return secrets/credentials in plaintext.
+if printf '%s' "$CMD" | grep -Eiq 'aws[[:space:]].*(secretsmanager[[:space:]]+get-secret-value|kms[[:space:]]+decrypt|get-password-data|get-session-token|(ssm[[:space:]]+get-parameter))'; then
+  deny "Blocked: command reads secret/credential material. The read-only role denies these; do not attempt to exfiltrate secrets."
+fi
+
+# Block destructive IaC operations.
+if printf '%s' "$CMD" | grep -Eiq '(pulumi[[:space:]]+(up|destroy|cancel|import)|pulumi[[:space:]]+state[[:space:]]+delete|terraform[[:space:]]+(apply|destroy|import))'; then
+  deny "Blocked: destructive IaC operation. This workspace only previews/inspects infrastructure."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "AWS_PROFILE": "bootstrap-ro-test",
+    "AWS_REGION": "eu-central-1",
+    "AWS_PAGER": ""
+  },
+  "permissions": {
+    "defaultMode": "plan",
+    "allow": [
+      "Bash(aws sts get-caller-identity:*)",
+      "Bash(aws s3 ls:*)",
+      "Bash(aws s3api list-*:*)",
+      "Bash(aws s3api get-bucket-*:*)",
+      "Bash(aws s3api head-*:*)",
+      "Bash(aws * describe-*:*)",
+      "Bash(aws * list-*:*)",
+      "Bash(aws * get-*:*)",
+      "Bash(aws logs filter-log-events:*)",
+      "Bash(aws logs get-log-events:*)",
+      "Bash(aws logs start-query:*)",
+      "Bash(pulumi stack:*)",
+      "Bash(pulumi preview:*)",
+      "Bash(pulumi about:*)"
+    ],
+    "deny": [
+      "Bash(aws * create-*:*)",
+      "Bash(aws * delete-*:*)",
+      "Bash(aws * put-*:*)",
+      "Bash(aws * update-*:*)",
+      "Bash(aws * modify-*:*)",
+      "Bash(aws * remove-*:*)",
+      "Bash(aws * attach-*:*)",
+      "Bash(aws * detach-*:*)",
+      "Bash(aws * associate-*:*)",
+      "Bash(aws * run-instances:*)",
+      "Bash(aws * terminate-*:*)",
+      "Bash(aws * start-*:*)",
+      "Bash(aws * stop-*:*)",
+      "Bash(aws * reboot-*:*)",
+      "Bash(aws iam *)",
+      "Bash(aws s3 rm:*)",
+      "Bash(aws s3 cp:*)",
+      "Bash(aws s3 mv:*)",
+      "Bash(aws s3 sync:*)",
+      "Bash(aws secretsmanager get-secret-value:*)",
+      "Bash(aws kms decrypt:*)",
+      "Bash(aws ssm get-parameter*:*)",
+      "Bash(aws cloudformation deploy:*)",
+      "Bash(aws cloudformation create-*:*)",
+      "Bash(aws cloudformation update-*:*)",
+      "Bash(aws cloudformation delete-*:*)",
+      "Bash(aws cloudformation execute-*:*)",
+      "Bash(aws * --profile *prod*)",
+      "Bash(AWS_PROFILE=*prod* *)",
+      "Bash(pulumi up:*)",
+      "Bash(pulumi destroy:*)",
+      "Bash(pulumi cancel:*)",
+      "Bash(pulumi state delete:*)",
+      "Bash(terraform apply:*)",
+      "Bash(terraform destroy:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/aws-readonly-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,6 @@
       "Bash(aws * get-*:*)",
       "Bash(aws logs filter-log-events:*)",
       "Bash(aws logs get-log-events:*)",
-      "Bash(aws logs start-query:*)",
       "Bash(pulumi stack:*)",
       "Bash(pulumi preview:*)",
       "Bash(pulumi about:*)"

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ build
 .quality-reports
 .wily
 .tmp
+
+# Claude Code per-developer local overrides (may carry prod-readonly profile)
+.claude/settings.local.json

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@
 - [pulumi-bootstrap-kms.md](pulumi-bootstrap-kms.md): Bootstrap KMS architecture, stage-0/stage-1 split, and downstream repository onboarding.
 - [pulumi-github-automation.md](pulumi-github-automation.md): ECR runner image, PR comment commands, and drift detection workflows.
 - [pulumi-policy-pack.md](pulumi-policy-pack.md): Pulumi CrossGuard Policy Pack rules, enforcement points, and coverage gate.
+- [pulumi-claude-readonly.md](pulumi-claude-readonly.md): Read-only IAM role and Claude Code setup for secure AI-native AWS access.

--- a/docs/pulumi-claude-readonly.md
+++ b/docs/pulumi-claude-readonly.md
@@ -1,0 +1,95 @@
+# Claude read-only AWS access
+
+AI-native DevOps with Claude Code against AWS, done securely. The boundary that
+actually holds is a **read-only IAM role with secret reads explicitly denied**,
+assumed with **short-lived, MFA-gated credentials**. Claude Code permission
+rules and the PreToolUse hook are defense-in-depth on top — they reduce prompts
+and catch accidents, but they are not the security boundary.
+
+> Account model: this repository is a **single AWS account** with `test` and
+> `prod` separated by Pulumi stacks. "Read-only to test and prod" therefore means
+> read-only to the account. The role is environment-scoped only to avoid a name
+> collision between the two stacks.
+
+## 1. The role (managed here, in Pulumi)
+
+`infra/iam/readonly.py` provisions `ClaudeReadOnly-<repo>-<env>` when the
+`claudeReadonlyPrincipalArns` config lists at least one principal:
+
+- Trust policy: only the listed IAM principals may `sts:AssumeRole`, and only
+  with `aws:MultiFactorAuthPresent = true`.
+- `max_session_duration = 3600` (1h) — prod re-auths often.
+- AWS-managed `ReadOnlyAccess` attached, **plus** an explicit `Deny` on the
+  sensitive reads `ReadOnlyAccess` would otherwise grant
+  (`secretsmanager:GetSecretValue`, `kms:Decrypt`, `ssm:GetParameter*`,
+  `lambda:GetFunction`, `ec2:GetPasswordData`, `*:GetAuthorizationToken`,
+  `sts:GetSessionToken`, `cognito-identity:Get*`). This closes the
+  "read-only still leaks secrets / is an exfiltration primitive" gap, which
+  matters here because the stack uses KMS + Pulumi secrets heavily.
+
+Enable it:
+
+```bash
+# One IAM user ARN per developer laptop allowed to assume the read-only role.
+pulumi config set --path 'claudeReadonlyPrincipalArns[0]' \
+  arn:aws:iam::891377212104:user/<your-iam-user>
+pulumi up            # exports claudeReadonlyRoleArn
+```
+
+## 2. The laptop (assume-role + MFA bridge — no long-lived prod keys)
+
+This replaces the old static prod access keys. The base IAM user holds keys with
+**only** `sts:AssumeRole` power; everything real comes from the short-lived role
+session.
+
+`~/.aws/config` (note: **no `[default]` profile**, so a bare `aws …` errors
+instead of silently hitting the account):
+
+```ini
+[profile bootstrap-ro-test]
+role_arn         = arn:aws:iam::891377212104:role/ClaudeReadOnly-bootstrap-infrastructure-test
+source_profile   = bootstrap            # base IAM user, AssumeRole-only
+mfa_serial       = arn:aws:iam::891377212104:mfa/<your-iam-user>
+duration_seconds = 3600
+region           = eu-central-1
+
+[profile bootstrap-ro-prod]
+role_arn         = arn:aws:iam::891377212104:role/ClaudeReadOnly-bootstrap-infrastructure-prod
+source_profile   = bootstrap
+mfa_serial       = arn:aws:iam::891377212104:mfa/<your-iam-user>
+duration_seconds = 3600
+region           = eu-central-1
+```
+
+`~/.aws/credentials` holds only the base user's keys under `[bootstrap]`. Verify:
+
+```bash
+aws sts get-caller-identity --profile bootstrap-ro-test   # prompts for MFA code
+```
+
+Then **delete the old long-lived prod access keys** in IAM.
+
+### Target end-state
+
+When `prod` moves to its own AWS account (the real blast-radius upgrade), switch
+this role to an IAM Identity Center (SSO) permission set and use
+`aws configure sso` / `aws sso login` — no keys on disk at all.
+
+## 3. Claude Code guardrails (defense-in-depth)
+
+`.claude/settings.json` (committed) pins the session to `bootstrap-ro-test`,
+runs in `plan` mode, allows read verbs (`describe-*`/`get-*`/`list-*`/`s3 ls`),
+and denies mutating verbs, secret reads, prod profiles, and `pulumi up`/
+`destroy` / `terraform apply`. `.claude/hooks/aws-readonly-guard.sh` is a
+PreToolUse backstop that also inspects chained/compound commands the glob
+matcher can miss. For prod **reads**, use a gitignored
+`.claude/settings.local.json` with `AWS_PROFILE=bootstrap-ro-prod`.
+
+These are deliberately *not* the boundary — a determined bypass defeats a regex
+over shell text. The read-only IAM credentials are what make a bypass harmless.
+
+## 4. Attribution & audit
+
+The role is dedicated to the agent, so CloudTrail cleanly attributes its calls
+(`AssumedRole` sessions). Alert on `AccessDenied` from the role's sessions — a
+spike signals a prompt-injection trying to escalate.

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -14,13 +14,21 @@ from infra import (
     PulumiStateBuckets,
     S3BackupPlan,
 )
-from infra.iam import GitHubOidcRoles
+from infra.config import claude_readonly_principal_arns
+from infra.iam import ClaudeReadOnlyRole, GitHubOidcRoles
 
 logging = CentralLoggingBuckets("central-logging")
 state = PulumiStateBuckets("pulumi-state")
 secrets = PulumiSecretsKeys("pulumi-secrets")
 oidc = GitHubOidcRoles("github-oidc", secrets_key_arns=secrets.key_arns)
 automation = GitHubAutomation("github-automation")
+
+readonly_principal_arns = claude_readonly_principal_arns()
+if readonly_principal_arns:
+    claude_readonly = ClaudeReadOnlyRole(
+        "claude-readonly", principal_arns=readonly_principal_arns
+    )
+    pulumi.export("claudeReadonlyRoleArn", claude_readonly.role.arn)
 
 backup_targets = [logging.bucket.arn, *state.bucket_arns.values()]
 S3BackupPlan("s3-backup", backup_target_arns=backup_targets)

--- a/pulumi/infra/config.py
+++ b/pulumi/infra/config.py
@@ -24,6 +24,7 @@ class RepoSettings:
     github_token: str | None
     github_oidc_provider_arn: str | None
     managed_repo_overrides: list["ManagedRepository"] | None = field(default=None)
+    claude_readonly_principal_arns: list[str] | None = field(default=None)
 
 
 @dataclass
@@ -117,6 +118,36 @@ settings.managed_repo_overrides = _load_managed_repo_overrides(
 )
 
 
+def _load_claude_readonly_principal_arns(raw: Any) -> list[str] | None:
+    """Normalize claudeReadonlyPrincipalArns config into a list of IAM ARNs."""
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        raise ValueError(
+            "claudeReadonlyPrincipalArns config must be a list of IAM principal ARNs."
+        )
+    arns: list[str] = []
+    for item in raw:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(
+                "Each claudeReadonlyPrincipalArns entry must be a non-empty ARN string."
+            )
+        arns.append(item.strip())
+    if not arns:
+        raise ValueError("claudeReadonlyPrincipalArns config cannot be empty.")
+    return arns
+
+
+settings.claude_readonly_principal_arns = _load_claude_readonly_principal_arns(
+    cfg.get_object("claudeReadonlyPrincipalArns")
+)
+
+
+def claude_readonly_principal_arns() -> list[str]:
+    """Return the IAM principal ARNs allowed to assume the Claude read-only role."""
+    return list(settings.claude_readonly_principal_arns or [])
+
+
 def _sanitize_bucket_component(value: str, label: str) -> str:
     """Return a DNS-safe S3 bucket component derived from user input."""
     normalized = value.strip().lower()
@@ -208,6 +239,19 @@ def automation_role_name(repo_name: str) -> str:
     if len(name) > 64:
         raise ValueError(
             "Combined repo/environment produce automation role name "
+            f"'{name}' longer than 64 characters."
+        )
+    return name
+
+
+def claude_readonly_role_name(repo_name: str) -> str:
+    """Compute the Claude read-only role name for this repository/environment."""
+    repo_part = _sanitize_bucket_component(repo_name, "repoSlug").replace(".", "-")
+    env_part = _sanitize_bucket_component(settings.environment, "environment")
+    name = f"ClaudeReadOnly-{repo_part}-{env_part}"
+    if len(name) > 64:
+        raise ValueError(
+            "Combined repo/environment produce Claude read-only role name "
             f"'{name}' longer than 64 characters."
         )
     return name

--- a/pulumi/infra/iam/__init__.py
+++ b/pulumi/infra/iam/__init__.py
@@ -1,5 +1,6 @@
 """IAM component exports for Pulumi stacks."""
 
 from .github_oidc import GitHubOidcRoles
+from .readonly import ClaudeReadOnlyRole
 
-__all__ = ("GitHubOidcRoles",)
+__all__ = ("ClaudeReadOnlyRole", "GitHubOidcRoles")

--- a/pulumi/infra/iam/readonly.py
+++ b/pulumi/infra/iam/readonly.py
@@ -1,0 +1,132 @@
+"""Read-only IAM role for Claude Code / AI-assisted AWS investigation."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+
+import pulumi_aws as aws
+
+import pulumi
+
+from ..config import claude_readonly_role_name, settings
+from ..utils.tags import base_tags
+
+READ_ONLY_MANAGED_POLICY_ARN = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+_READONLY_SESSION_DURATION_SECONDS = 3600
+
+# AWS' ReadOnlyAccess grants these sensitive reads, which would let a read-only
+# principal exfiltrate secrets/credentials in plaintext. They are denied
+# explicitly so the role stays read-only WITHOUT being a secret-exfil primitive.
+_DENIED_SENSITIVE_ACTIONS = [
+    "secretsmanager:GetSecretValue",
+    "secretsmanager:BatchGetSecretValue",
+    "kms:Decrypt",
+    "kms:GenerateDataKey",
+    "kms:GenerateDataKeyWithoutPlaintext",
+    "ssm:GetParameter",
+    "ssm:GetParameters",
+    "ssm:GetParametersByPath",
+    "lambda:GetFunction",
+    "lambda:GetFunctionConfiguration",
+    "ec2:GetPasswordData",
+    "ec2:GetConsoleOutput",
+    "ec2:GetConsoleScreenshot",
+    "ecr:GetAuthorizationToken",
+    "ecr-public:GetAuthorizationToken",
+    "codeartifact:GetAuthorizationToken",
+    "sts:GetSessionToken",
+    "cognito-identity:GetCredentialsForIdentity",
+    "cognito-identity:GetOpenIdToken",
+]
+
+
+def _readonly_assume_role_policy(principal_arns: Sequence[str]) -> str:
+    """Build a trust policy letting the given principals assume the role with MFA."""
+    return json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"AWS": list(principal_arns)},
+                    "Action": "sts:AssumeRole",
+                    "Condition": {"Bool": {"aws:MultiFactorAuthPresent": "true"}},
+                }
+            ],
+        }
+    )
+
+
+def _readonly_deny_policy() -> str:
+    """Return the explicit-deny policy that blocks secret and credential reads."""
+    return json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "DenySecretAndCredentialReads",
+                    "Effect": "Deny",
+                    "Action": _DENIED_SENSITIVE_ACTIONS,
+                    "Resource": "*",
+                }
+            ],
+        }
+    )
+
+
+class ClaudeReadOnlyRole(pulumi.ComponentResource):
+    """Provision a read-only IAM role for AI-assisted AWS investigation."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        principal_arns: Sequence[str],
+        opts: pulumi.ResourceOptions | None = None,
+    ) -> None:
+        """Initialize the read-only role assumable by the given principals."""
+        super().__init__("bootstrap:iam:ClaudeReadOnlyRole", name, None, opts)
+
+        principals = list(principal_arns)
+        if not principals:
+            raise ValueError(
+                "ClaudeReadOnlyRole requires at least one principal ARN to trust."
+            )
+
+        repo_name = settings.repo or settings.environment
+        role_name = claude_readonly_role_name(repo_name)
+        base_opts = pulumi.ResourceOptions(parent=self)
+
+        role = aws.iam.Role(
+            f"{name}-role",
+            name=role_name,
+            assume_role_policy=_readonly_assume_role_policy(principals),
+            max_session_duration=_READONLY_SESSION_DURATION_SECONDS,
+            tags=base_tags(
+                {
+                    "Purpose": "claude-readonly",
+                    "App": repo_name,
+                }
+            ),
+            opts=base_opts,
+        )
+
+        readonly_attachment = aws.iam.RolePolicyAttachment(
+            f"{name}-readonly-attachment",
+            role=role.name,
+            policy_arn=READ_ONLY_MANAGED_POLICY_ARN,
+            opts=base_opts,
+        )
+
+        secret_deny_policy = aws.iam.RolePolicy(
+            f"{name}-deny-secrets",
+            role=role.id,
+            policy=_readonly_deny_policy(),
+            opts=base_opts,
+        )
+
+        self.role = role
+        self.readonly_attachment = readonly_attachment
+        self.secret_deny_policy = secret_deny_policy
+        self.register_outputs({"role_arn": role.arn})

--- a/scripts/validate_iam_policies.py
+++ b/scripts/validate_iam_policies.py
@@ -24,6 +24,7 @@ os.environ.setdefault("PULUMI_ALLOW_TEST_DEFAULTS", "1")
 
 from infra.automation import _automation_policy
 from infra.iam.github_oidc import _deploy_policy
+from infra.iam.readonly import _readonly_deny_policy
 from infra.logging_bucket import (
     _log_bucket_policy,
 )
@@ -68,6 +69,11 @@ def build_policy_documents(account_id: str) -> list[PolicyDocumentSpec]:
         PolicyDocumentSpec(
             name="github-automation-bootstrap-policy",
             policy_document=_automation_policy(account_id),
+            policy_type="IDENTITY_POLICY",
+        ),
+        PolicyDocumentSpec(
+            name="claude-readonly-deny-policy",
+            policy_document=_readonly_deny_policy(),
             policy_type="IDENTITY_POLICY",
         ),
         PolicyDocumentSpec(

--- a/tests/unit/test_components.py
+++ b/tests/unit/test_components.py
@@ -16,7 +16,7 @@ from infra import (
     pulumi_secrets,
     pulumi_state,
 )
-from infra.iam import GitHubOidcRoles, github_oidc
+from infra.iam import ClaudeReadOnlyRole, GitHubOidcRoles, github_oidc
 from infra.utils.outputs import future_output
 
 
@@ -324,6 +324,73 @@ def test_task_roles_module_has_no_exports():
     from infra.iam import task_roles
 
     assert task_roles.__all__ == []  # nosec B101
+
+
+def test_claude_readonly_role_emits_role_and_guardrail_policies(
+    pulumi_mocks, monkeypatch
+):  # noqa: ARG001
+    monkeypatch.setattr(config.settings, "repo", "bootstrap-infrastructure")
+    monkeypatch.setattr(config.settings, "environment", "test")
+
+    readonly = ClaudeReadOnlyRole(
+        "claude-readonly",
+        principal_arns=["arn:aws:iam::123456789012:user/dev"],
+    )
+
+    # Assert on each resource's own resolved outputs (not the shared mock list,
+    # whose async child-resource ordering is not deterministic across the suite).
+    role_arn = _sync_await(future_output(readonly.role.arn))
+    role_name = _sync_await(future_output(readonly.role.name))
+    assume_role_policy = _sync_await(future_output(readonly.role.assume_role_policy))
+    max_session_duration = _sync_await(
+        future_output(readonly.role.max_session_duration)
+    )
+    tags = _sync_await(future_output(readonly.role.tags))
+    attachment_policy_arn = _sync_await(
+        future_output(readonly.readonly_attachment.policy_arn)
+    )
+    deny_policy = _sync_await(future_output(readonly.secret_deny_policy.policy))
+
+    assert role_name == "ClaudeReadOnly-bootstrap-infrastructure-test"  # nosec B101
+    assert role_arn.endswith(  # nosec B101
+        ":role/ClaudeReadOnly-bootstrap-infrastructure-test"
+    )
+    assert max_session_duration == 3600  # nosec B101
+    assert "aws:MultiFactorAuthPresent" in assume_role_policy  # nosec B101
+    assert tags["Purpose"] == "claude-readonly"  # nosec B101
+    assert attachment_policy_arn == "arn:aws:iam::aws:policy/ReadOnlyAccess"  # nosec B101
+    assert "DenySecretAndCredentialReads" in deny_policy  # nosec B101
+    assert '"Effect": "Deny"' in deny_policy  # nosec B101
+
+
+def test_claude_readonly_role_requires_principals(monkeypatch):
+    monkeypatch.setattr(config.settings, "repo", "bootstrap-infrastructure")
+    monkeypatch.setattr(config.settings, "environment", "test")
+    with pytest.raises(ValueError, match="at least one principal"):
+        ClaudeReadOnlyRole("claude-readonly-empty", principal_arns=[])
+
+
+def test_stack_main_creates_readonly_role_when_configured(monkeypatch):
+    config.managed_repositories.cache_clear()
+    try:
+        monkeypatch.setattr(config.settings, "repo", "repo")
+        monkeypatch.setattr(config.settings, "environment", "test")
+        monkeypatch.setattr(config.settings, "replication_region", "us-west-2")
+        monkeypatch.setattr(
+            config.settings,
+            "github_oidc_provider_arn",
+            "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com",
+        )
+        monkeypatch.setattr(config.settings, "managed_repo_overrides", None)
+        monkeypatch.setattr(
+            config.settings,
+            "claude_readonly_principal_arns",
+            ["arn:aws:iam::123456789012:user/dev"],
+        )
+        stack_path = Path(__file__).resolve().parents[2] / "pulumi" / "__main__.py"
+        runpy.run_path(str(stack_path))
+    finally:
+        config.managed_repositories.cache_clear()
 
 
 def test_stack_main_executes(monkeypatch):

--- a/tests/unit/test_components.py
+++ b/tests/unit/test_components.py
@@ -352,13 +352,17 @@ def test_claude_readonly_role_emits_role_and_guardrail_policies(
     deny_policy = _sync_await(future_output(readonly.secret_deny_policy.policy))
 
     assert role_name == "ClaudeReadOnly-bootstrap-infrastructure-test"  # nosec B101
+    assert role_arn is not None  # nosec B101
     assert role_arn.endswith(  # nosec B101
         ":role/ClaudeReadOnly-bootstrap-infrastructure-test"
     )
     assert max_session_duration == 3600  # nosec B101
+    assert assume_role_policy is not None  # nosec B101
     assert "aws:MultiFactorAuthPresent" in assume_role_policy  # nosec B101
+    assert tags is not None  # nosec B101
     assert tags["Purpose"] == "claude-readonly"  # nosec B101
     assert attachment_policy_arn == "arn:aws:iam::aws:policy/ReadOnlyAccess"  # nosec B101
+    assert deny_policy is not None  # nosec B101
     assert "DenySecretAndCredentialReads" in deny_policy  # nosec B101
     assert '"Effect": "Deny"' in deny_policy  # nosec B101
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -17,6 +17,8 @@ from infra.config import (
     _sanitize_bucket_component,
     automation_role_name,
     central_logging_bucket_name,
+    claude_readonly_principal_arns,
+    claude_readonly_role_name,
     pulumi_secrets_alias_name_for_repo,
     pulumi_secrets_provider_for_repo,
     runner_ecr_repository_name,
@@ -243,3 +245,47 @@ def test_central_logging_bucket_length_guard(monkeypatch):
     monkeypatch.setattr(settings, "environment", "e" * 40)
     with pytest.raises(ValueError):
         central_logging_bucket_name("regionname")
+
+
+def test_claude_readonly_role_name(monkeypatch):
+    """Claude read-only role name is sanitized and environment-scoped."""
+    monkeypatch.setattr(settings, "environment", "test")
+    assert claude_readonly_role_name("My.Repo") == "ClaudeReadOnly-my-repo-test"  # nosec B101
+
+
+def test_claude_readonly_role_name_length_guard(monkeypatch):
+    """Claude read-only role name should not exceed the IAM 64-char limit."""
+    monkeypatch.setattr(settings, "environment", "e" * 40)
+    with pytest.raises(ValueError):
+        claude_readonly_role_name("r" * 40)
+
+
+def test_load_claude_readonly_principal_arns_validation():
+    """claudeReadonlyPrincipalArns input validation enforces structure."""
+    assert config._load_claude_readonly_principal_arns(None) is None  # nosec B101
+    with pytest.raises(ValueError):
+        config._load_claude_readonly_principal_arns("not-a-list")
+    with pytest.raises(ValueError):
+        config._load_claude_readonly_principal_arns([])
+    with pytest.raises(ValueError):
+        config._load_claude_readonly_principal_arns([123])
+    with pytest.raises(ValueError):
+        config._load_claude_readonly_principal_arns([" "])
+
+
+def test_load_claude_readonly_principal_arns_success():
+    """Valid claudeReadonlyPrincipalArns values are trimmed and returned."""
+    arns = config._load_claude_readonly_principal_arns(
+        [" arn:aws:iam::123456789012:user/dev "]
+    )
+    assert arns == ["arn:aws:iam::123456789012:user/dev"]  # nosec B101
+
+
+def test_claude_readonly_principal_arns_getter(monkeypatch):
+    """The getter returns a copy of configured ARNs, or an empty list."""
+    monkeypatch.setattr(
+        settings, "claude_readonly_principal_arns", ["arn:aws:iam::1:user/a"]
+    )
+    assert claude_readonly_principal_arns() == ["arn:aws:iam::1:user/a"]  # nosec B101
+    monkeypatch.setattr(settings, "claude_readonly_principal_arns", None)
+    assert claude_readonly_principal_arns() == []  # nosec B101

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -2,7 +2,11 @@ import json
 
 from infra.automation import _automation_assume_role_policy, _automation_policy
 from infra.iam.github_oidc import _assume_role_policy, _deploy_policy
-from infra.iam.readonly import _readonly_assume_role_policy, _readonly_deny_policy
+from infra.iam.readonly import (
+    _DENIED_SENSITIVE_ACTIONS,
+    _readonly_assume_role_policy,
+    _readonly_deny_policy,
+)
 from infra.logging_bucket import _log_bucket_policy
 from infra.pulumi_state import _bucket_policy
 
@@ -116,18 +120,28 @@ def test_readonly_deny_policy_blocks_secret_and_credential_reads():
     assert statement["Sid"] == "DenySecretAndCredentialReads"  # nosec B101
     assert statement["Effect"] == "Deny"  # nosec B101
     assert statement["Resource"] == "*"  # nosec B101
-    actions = statement["Action"]
+    # The policy must deny every action in the curated list, in full.
+    assert statement["Action"] == _DENIED_SENSITIVE_ACTIONS  # nosec B101
     for blocked in (
         "secretsmanager:GetSecretValue",
+        "secretsmanager:BatchGetSecretValue",
         "kms:Decrypt",
         "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:GetParametersByPath",
         "lambda:GetFunction",
+        "lambda:GetFunctionConfiguration",
         "ec2:GetPasswordData",
+        "ec2:GetConsoleOutput",
+        "ec2:GetConsoleScreenshot",
         "ecr:GetAuthorizationToken",
+        "ecr-public:GetAuthorizationToken",
+        "codeartifact:GetAuthorizationToken",
         "sts:GetSessionToken",
         "cognito-identity:GetCredentialsForIdentity",
+        "cognito-identity:GetOpenIdToken",
     ):
-        assert blocked in actions  # nosec B101
+        assert blocked in _DENIED_SENSITIVE_ACTIONS  # nosec B101
 
 
 def test_log_bucket_policy_contains_required_statements():

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -2,6 +2,7 @@ import json
 
 from infra.automation import _automation_assume_role_policy, _automation_policy
 from infra.iam.github_oidc import _assume_role_policy, _deploy_policy
+from infra.iam.readonly import _readonly_assume_role_policy, _readonly_deny_policy
 from infra.logging_bucket import _log_bucket_policy
 from infra.pulumi_state import _bucket_policy
 
@@ -89,6 +90,44 @@ def test_automation_policy_scopes_to_bootstrap_services():
     }
     assert statements["ManageBootstrapBackup"]["Action"] == ["backup:*"]  # nosec B101
     assert statements["ManageBootstrapEcr"]["Action"] == ["ecr:*"]  # nosec B101
+
+
+def test_readonly_assume_role_policy_requires_mfa_for_principals():
+    policy = json.loads(
+        _readonly_assume_role_policy(
+            ["arn:aws:iam::123456789012:user/dev", "arn:aws:iam::123456789012:role/ci"]
+        )
+    )
+    statement = policy["Statement"][0]
+    assert policy["Version"] == "2012-10-17"  # nosec B101
+    assert statement["Effect"] == "Allow"  # nosec B101
+    assert statement["Principal"]["AWS"] == [  # nosec B101
+        "arn:aws:iam::123456789012:user/dev",
+        "arn:aws:iam::123456789012:role/ci",
+    ]
+    assert statement["Action"] == "sts:AssumeRole"  # nosec B101
+    assert statement["Condition"]["Bool"]["aws:MultiFactorAuthPresent"] == "true"  # nosec B101
+
+
+def test_readonly_deny_policy_blocks_secret_and_credential_reads():
+    policy = json.loads(_readonly_deny_policy())
+    statement = policy["Statement"][0]
+    assert policy["Version"] == "2012-10-17"  # nosec B101
+    assert statement["Sid"] == "DenySecretAndCredentialReads"  # nosec B101
+    assert statement["Effect"] == "Deny"  # nosec B101
+    assert statement["Resource"] == "*"  # nosec B101
+    actions = statement["Action"]
+    for blocked in (
+        "secretsmanager:GetSecretValue",
+        "kms:Decrypt",
+        "ssm:GetParameter",
+        "lambda:GetFunction",
+        "ec2:GetPasswordData",
+        "ecr:GetAuthorizationToken",
+        "sts:GetSessionToken",
+        "cognito-identity:GetCredentialsForIdentity",
+    ):
+        assert blocked in actions  # nosec B101
 
 
 def test_log_bucket_policy_contains_required_statements():


### PR DESCRIPTION
Refs #75.

## What

Adds a dedicated, MFA-gated **read-only IAM role** for AI-assisted DevOps (Claude Code) against AWS, with the security boundary enforced by **IAM** — not by the agent's own rules.

> Base branch note: stacked on `1-implement-…` (the active dev line), not `main`. `main` diverged from this line at the initial commit and implements the infra differently (no `policy_pack/`, no `scripts/validate_iam_policies.py`), so this change cannot be based on `main`. Reviewers should diff against the dev branch.

### Boundary — Pulumi (`pulumi/infra/iam/readonly.py`)
- `ClaudeReadOnly-<repo>-<env>`: trust restricted to configured principals **with `aws:MultiFactorAuthPresent`**, `max_session_duration=3600`.
- AWS `ReadOnlyAccess` **+ explicit Deny** on secret/credential reads (`secretsmanager:GetSecretValue`, `kms:Decrypt`, `ssm:GetParameter*`, `lambda:GetFunction`, `ec2:GetPasswordData`, `*:GetAuthorizationToken`, `sts:GetSessionToken`, `cognito-identity:Get*`) — read-only without being a secret-exfil primitive (matters here: stack leans on KMS/Pulumi secrets).
- Opt-in: emitted only when `claudeReadonlyPrincipalArns` is set. Registered with `check-iam` (Access Analyzer).

### Defense-in-depth — `.claude/` (not the boundary)
- `settings.json`: read-only profile, `plan` mode, allow `describe-*`/`get-*`/`list-*`/`s3 ls`, deny mutations / secret reads / prod profile / `pulumi up`/`destroy` / `terraform apply`.
- `hooks/aws-readonly-guard.sh`: PreToolUse backstop that also inspects chained/compound commands the glob matcher misses.

### Docs
- `docs/pulumi-claude-readonly.md`: laptop assume-role + MFA bridge (kills long-lived prod keys), SSO end-state, attribution/audit.

## Verification (local)
`ruff format`+`check`, `mypy`, **89 unit + 29 structural/policy tests** pass; `readonly.py` / `config.py` / `__main__.py` at **100%** coverage. Guard hook functionally tested (denies mutations/secret-reads/prod-profile/`pulumi up`/chained `terminate`; allows reads).

## Follow-ups (not in scope)
- IAM Identity Center (SSO) + per-account split for prod — documented end-state.
- No AWS MCP server (CLI-only).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an MFA-gated AWS read-only IAM role for Claude Code with explicit blocks on secret/credential reads, plus guardrails and docs for secure usage. The role is created only when `claudeReadonlyPrincipalArns` is set and its ARN is exported for clients (Refs #75).

- **New Features**
  - Provision `ClaudeReadOnly-<repo>-<env>` in `pulumi/infra/iam/readonly.py`: trust only listed principals with `aws:MultiFactorAuthPresent`, 1h session, attach AWS `ReadOnlyAccess`, and explicitly deny secret/credential reads (e.g., `secretsmanager:GetSecretValue`, `kms:Decrypt`, `ssm:GetParameter*`, `lambda:GetFunction*`, `ec2:GetPasswordData`, `*:GetAuthorizationToken`, `sts:GetSessionToken`, `cognito-identity:Get*`).
  - Conditional wiring in `pulumi/__main__.py` driven by `claudeReadonlyPrincipalArns`; exports `claudeReadonlyRoleArn`. Config helpers in `pulumi/infra/config.py` validate ARNs and build a bounded role name.
  - Defense-in-depth guardrails in `.claude`: `settings.json` runs in plan mode with allow/deny lists (cleaned up redundant allows). `hooks/aws-readonly-guard.sh` now matches `aws` as a real command token (handles wrappers and `/usr/bin/aws`, ignores substrings), and blocks prod profiles, mutating commands, secret reads, and destructive IaC.
  - Documentation and validation: `docs/pulumi-claude-readonly.md`; register the deny policy in `scripts/validate_iam_policies.py`; tests cover the role, policies, config, and stack wiring (tightened to assert the full deny list).

- **Migration**
  - Set `claudeReadonlyPrincipalArns[]` in Pulumi config and run `pulumi up` to create and export `claudeReadonlyRoleArn`.
  - Update local AWS profiles to assume the role with MFA; remove long‑lived prod keys. Optionally add `.claude/settings.local.json` to switch `AWS_PROFILE` for prod reads.

<sup>Written for commit d9db1302d287c02d28f698eca3216d2b3824f51e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/bootstrap-infrastructure/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

